### PR TITLE
support Windows colors

### DIFF
--- a/cmd/git-chglog/initializer.go
+++ b/cmd/git-chglog/initializer.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/fatih/color"
+	"github.com/mattn/go-colorable"
 	gitcmd "github.com/tsuyoshiwada/go-gitcmd"
 )
 
@@ -30,7 +31,7 @@ func NewInitializer(
 	return &Initializer{
 		ctx:             ctx,
 		fs:              fs,
-		logger:          NewLogger(ctx.Stdout, ctx.Stderr, false, false),
+		logger:          NewLogger(colorable.NewColorableStdout(), colorable.NewColorableStderr(), false, false),
 		questioner:      questioner,
 		configBuilder:   configBuilder,
 		templateBuilder: templateBuilder,

--- a/cmd/git-chglog/initializer.go
+++ b/cmd/git-chglog/initializer.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 
 	"github.com/fatih/color"
-	"github.com/mattn/go-colorable"
 	gitcmd "github.com/tsuyoshiwada/go-gitcmd"
 )
 
@@ -31,7 +30,7 @@ func NewInitializer(
 	return &Initializer{
 		ctx:             ctx,
 		fs:              fs,
-		logger:          NewLogger(colorable.NewColorableStdout(), colorable.NewColorableStderr(), false, false),
+		logger:          NewLogger(ctx.Stdout, ctx.Stderr, false, false),
 		questioner:      questioner,
 		configBuilder:   configBuilder,
 		templateBuilder: templateBuilder,

--- a/cmd/git-chglog/main.go
+++ b/cmd/git-chglog/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/fatih/color"
+	"github.com/mattn/go-colorable"
 	gitcmd "github.com/tsuyoshiwada/go-gitcmd"
 	"github.com/urfave/cli"
 )
@@ -120,8 +121,8 @@ func main() {
 			initializer := NewInitializer(
 				&InitContext{
 					WorkingDir: wd,
-					Stdout:     os.Stdout,
-					Stderr:     os.Stderr,
+					Stdout:     colorable.NewColorableStdout(),
+					Stderr:     colorable.NewColorableStderr(),
 				},
 				fs,
 				NewQuestioner(
@@ -141,8 +142,8 @@ func main() {
 		chglogCLI := NewCLI(
 			&CLIContext{
 				WorkingDir: wd,
-				Stdout:     os.Stdout,
-				Stderr:     os.Stderr,
+				Stdout:     colorable.NewColorableStdout(),
+				Stderr:     colorable.NewColorableStderr(),
 				ConfigPath: c.String("config"),
 				OutputPath: c.String("output"),
 				Silent:     c.Bool("silent"),


### PR DESCRIPTION
## What does this do / why do we need it?

git-chglog does not support Windows colors.

## How this PR fixes the problem?

be nice

## What should your reviewer look out for in this PR?

use go-colorable instead of native os.Stdout/os.Stderr. This doesn't break on Linux or macOS.

## Check lists

* [ ] Test passed
* [ ] Coding style (indentation, etc)

Tests on Windows are already broken.
