### PR TITLE
Fix color output bug in windows help command

### DIFF
--- a/cmd/git-chglog/main.go
+++ b/cmd/git-chglog/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/fatih/color"
@@ -58,6 +59,10 @@ func main() {
 		ttl("OPTIONS:"),
 		ttl("EXAMPLE:"),
 	)
+
+	cli.HelpPrinter = func(w io.Writer, templ string, data interface{}) {
+		cli.HelpPrinterCustom(colorable.NewColorableStdout(), templ, data, nil)
+	}
 
 	app := cli.NewApp()
 	app.Name = "git-chglog"


### PR DESCRIPTION
## What does this do / why do we need it?

Fix color output bug in windows help command.


## How this PR fixes the problem?

* Use `mattn/go-colorable` io.Writer.


## What should your reviewer look out for in this PR?

* None


## Check lists

* [x] Test passed
* [x] Coding style (indentation, etc)


## Additional Comments (if any)

* None


## Which issue(s) does this PR fix?

<!--
fixes #
fixes #
-->
