### PR TITLE
Add `--next-tag` flag (EXPERIMENTAL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ USAGE:
 
     There are the following specification methods for <tag query>.
 
-    1. <old>..<new> - Commit contained in <new> tags from <old>.
+    1. <old>..<new> - Commit contained in <old> tags from <new>.
     2. <name>..     - Commit from the <name> to the latest tag.
     3. ..<name>     - Commit from the oldest tag to <name>.
     4. <name>       - Commit contained in <name>.
@@ -163,6 +163,7 @@ OPTIONS:
   --init                    generate the git-chglog configuration file in interactive
   --config value, -c value  specifies a different configuration file to pick up (default: ".chglog/config.yml")
   --output value, -o value  output path and filename for the changelogs. If not specified, output to stdout
+  --next-tag value          treat unreleased commits as specified tags (EXPERIMENTAL)
   --silent                  disable stdout output
   --no-color                disable color output [$NO_COLOR]
   --no-emoji                disable emoji output [$NO_EMOJI]
@@ -194,7 +195,7 @@ EXAMPLE:
 
   $ git-chglog --config custom/dir/config.yml
 
-    The above is a command that uses a configuration file placed other than ".chglog/config.yml".
+    The adove is a command that uses a configuration file placed other than ".chglog/config.yml".
 ```
 
 
@@ -484,6 +485,25 @@ See godoc [RenderData][doc-render-data] for available variables.
 
   There are times when you need your hands to write a great CHANGELOG.  
   By displaying it on the standard output, it makes it easy to change the contents.
+</details>
+
+<details>
+  <summary>Can I commit CHANGELOG changes before creating tags?</summary>
+
+  Yes, it can be solved by using the `--next-tag` flag.
+
+  For example, let's say you want to upgrade your project to `2.0.0`.  
+  You can create CHANGELOG containing `2.0.0` as follows.
+
+  ```bash
+  $ git-chglog --next-tag 2.0.0 -o CHANGELOG.md
+  $ git commit -am "release 2.0.0"
+  $ git tag 2.0.0
+  ```
+
+  The point to notice is that before actually creating a tag with git, it is conveying the next version with `--next-tag` :+1:
+
+  This is a step that is necessary for project operation in many cases.
 </details>
 
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ EXAMPLE:
 
   $ git-chglog --config custom/dir/config.yml
 
-    The adove is a command that uses a configuration file placed other than ".chglog/config.yml".
+    The above is a command that uses a configuration file placed other than ".chglog/config.yml".
 ```
 
 

--- a/chglog_test.go
+++ b/chglog_test.go
@@ -253,13 +253,18 @@ change message.`)
 	err := gen.Generate(buf, "")
 
 	assert.Nil(err)
-	assert.Equal(`<a name="2.0.0-beta.0"></a>
-## 2.0.0-beta.0 (2018-01-03)
+	assert.Equal(`<a name="unreleased"></a>
+## [Unreleased]
 
+### Bug Fixes
+- **core:** Fix commit
+
+
+<a name="2.0.0-beta.0"></a>
+## [2.0.0-beta.0] - 2018-01-03
 ### Features
-
-* **context:** Online breaking change
-* **router:** Muliple breaking change
+- **context:** Online breaking change
+- **router:** Muliple breaking change
 
 ### BREAKING CHANGE
 
@@ -270,28 +275,26 @@ change message.
 Online breaking change message.
 
 
-
 <a name="1.1.0"></a>
-## 1.1.0 (2018-01-02)
-
+## [1.1.0] - 2018-01-02
 ### Features
-
-* **parser:** New some super options #333
+- **parser:** New some super options #333
 
 ### Reverts
-
-* feat(core): Add foo bar @mention and issue #987
+- feat(core): Add foo bar @mention and issue #987
 
 ### Pull Requests
-
-* Merge pull request #1000 from tsuyoshiwada/patch-1
-* Merge pull request #999 from tsuyoshiwada/patch-1
+- Merge pull request #1000 from tsuyoshiwada/patch-1
+- Merge pull request #999 from tsuyoshiwada/patch-1
 
 
 <a name="1.0.0"></a>
-## 1.0.0 (2018-01-01)
-
+## 1.0.0 - 2018-01-01
 ### Features
+- **core:** Add foo bar
 
-* **core:** Add foo bar`, strings.TrimSpace(buf.String()))
+
+[Unreleased]: https://github.com/git-chglog/git-chglog/compare/2.0.0-beta.0...HEAD
+[2.0.0-beta.0]: https://github.com/git-chglog/git-chglog/compare/1.1.0...2.0.0-beta.0
+[1.1.0]: https://github.com/git-chglog/git-chglog/compare/1.0.0...1.1.0`, strings.TrimSpace(buf.String()))
 }

--- a/cmd/git-chglog/config.go
+++ b/cmd/git-chglog/config.go
@@ -257,6 +257,7 @@ func (config *Config) Convert(ctx *CLIContext) *chglog.Config {
 			RepositoryURL: info.RepositoryURL,
 		},
 		Options: &chglog.Options{
+			NextTag:              ctx.NextTag,
 			CommitFilters:        opts.Commits.Filters,
 			CommitSortBy:         opts.Commits.SortBy,
 			CommitGroupBy:        opts.CommitGroups.GroupBy,

--- a/cmd/git-chglog/context.go
+++ b/cmd/git-chglog/context.go
@@ -15,6 +15,7 @@ type CLIContext struct {
 	NoColor    bool
 	NoEmoji    bool
 	Query      string
+	NextTag    string
 }
 
 // InitContext ...

--- a/cmd/git-chglog/main.go
+++ b/cmd/git-chglog/main.go
@@ -89,6 +89,11 @@ func main() {
 			Usage: "output path and filename for the changelogs. If not specified, output to stdout",
 		},
 
+		cli.StringFlag{
+			Name:  "next-tag",
+			Usage: "treat unreleased commits as specified tags (EXPERIMENTAL)",
+		},
+
 		// silent
 		cli.BoolFlag{
 			Name:  "silent",
@@ -155,6 +160,7 @@ func main() {
 				NoColor:    c.Bool("no-color"),
 				NoEmoji:    c.Bool("no-emoji"),
 				Query:      c.Args().First(),
+				NextTag:    c.String("next-tag"),
 			},
 			fs,
 			NewConfigLoader(),

--- a/cmd/git-chglog/main.go
+++ b/cmd/git-chglog/main.go
@@ -53,7 +53,7 @@ func main() {
 
   $ {{.Name}} --config custom/dir/config.yml
 
-    The adove is a command that uses a configuration file placed other than ".chglog/config.yml".
+    The above is a command that uses a configuration file placed other than ".chglog/config.yml".
 `,
 		ttl("USAGE:"),
 		ttl("OPTIONS:"),

--- a/fields.go
+++ b/fields.go
@@ -106,7 +106,6 @@ type Version struct {
 
 // Unreleased is unreleased commit dataset
 type Unreleased struct {
-	Tag           *Tag
 	CommitGroups  []*CommitGroup
 	Commits       []*Commit
 	MergeCommits  []*Commit

--- a/testdata/type_scope_subject.md
+++ b/testdata/type_scope_subject.md
@@ -1,22 +1,56 @@
-{{range .Versions}}
-<a name="{{urlquery .Tag.Name}}"></a>
-## {{.Tag.Name}} ({{datetime "2006-01-02" .Tag.Date}})
-{{range .CommitGroups}}
-### {{.Title}}
-{{range .Commits}}
-* {{if ne .Scope ""}}**{{.Scope}}:** {{end}}{{.Subject}}{{end}}
-{{end}}{{if .RevertCommits}}
+{{ if .Versions -}}
+<a name="unreleased"></a>
+## [Unreleased]
+
+{{ if .Unreleased.CommitGroups -}}
+{{ range .Unreleased.CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{ range .Versions }}
+<a name="{{ .Tag.Name }}"></a>
+## {{ if .Tag.Previous }}[{{ .Tag.Name }}]{{ else }}{{ .Tag.Name }}{{ end }} - {{ datetime "2006-01-02" .Tag.Date }}
+{{ range .CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+
+{{- if .RevertCommits -}}
 ### Reverts
-{{range .RevertCommits}}
-* {{.Revert.Header}}{{end}}
-{{end}}{{if .MergeCommits}}
+{{ range .RevertCommits -}}
+- {{ .Revert.Header }}
+{{ end }}
+{{ end -}}
+
+{{- if .MergeCommits -}}
 ### Pull Requests
-{{range .MergeCommits}}
-* {{.Header}}{{end}}
-{{end}}{{range .NoteGroups}}
-### {{.Title}}
-{{range .Notes}}
-{{.Body}}
-{{end}}
-{{end}}
-{{end}}
+{{ range .MergeCommits -}}
+- {{ .Header }}
+{{ end }}
+{{ end -}}
+
+{{- if .NoteGroups -}}
+{{ range .NoteGroups -}}
+### {{ .Title }}
+{{ range .Notes }}
+{{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{- if .Versions }}
+[Unreleased]: {{ .Info.RepositoryURL }}/compare/{{ $latest := index .Versions 0 }}{{ $latest.Tag.Name }}...HEAD
+{{ range .Versions -}}
+{{ if .Tag.Previous -}}
+[{{ .Tag.Name }}]: {{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}
+{{ end -}}
+{{ end -}}
+{{ end -}}


### PR DESCRIPTION
<!-- Thank you for your contribution to git-chglog! Please replace {Please write here} with your description -->

## What does this do / why do we need it?

Added `--next-tag` flag to treat commits that have not yet tagged as specified tag names.
This is a function to include the commit for creating CHANGELOG in the release commit.

**EXAMPLE:**

```bash
$ git-chglog --next-tag 1.0.0
```


## How this PR fixes the problem?

* None


## What should your reviewer look out for in this PR?

* None


## Check lists

* [x] Test passed
* [x] Coding style (indentation, etc)


## Additional Comments (if any)

* None


## Which issue(s) does this PR fix?

* None

<!--
fixes #
fixes #
-->
