### PR TITLE
Add URL of output example for template style

### DIFF
--- a/cmd/git-chglog/config_builder.go
+++ b/cmd/git-chglog/config_builder.go
@@ -21,8 +21,9 @@ func NewConfigBuilder() ConfigBuilder {
 func (*configBuilderImpl) Build(ans *Answer) (string, error) {
 	var msgFormat *CommitMessageFormat
 
-	for _, f := range formats {
-		if f.Display == ans.CommitMessageFormat {
+	for _, ff := range formats {
+		f, _ := ff.(*CommitMessageFormat)
+		if f.display == ans.CommitMessageFormat {
 			msgFormat = f
 			break
 		}
@@ -65,7 +66,7 @@ options:
 		ans.Style,
 		defaultTemplateFilename,
 		repoURL,
-		msgFormat.Pattern,
+		msgFormat.pattern,
 		msgFormat.PatternMapString(),
 	)
 

--- a/cmd/git-chglog/config_builder_test.go
+++ b/cmd/git-chglog/config_builder_test.go
@@ -14,21 +14,21 @@ func TestConfigBulider(t *testing.T) {
 	out, err := builder.Build(&Answer{
 		RepositoryURL:       "https://github.com/git-chglog/git-chglog/git-chglog/",
 		Style:               styleNone,
-		CommitMessageFormat: fmtGitBasic.Display,
-		Template:            tplStandard,
+		CommitMessageFormat: fmtGitBasic.display,
+		Template:            tplStandard.display,
 	})
 
 	assert.Nil(err)
 	assert.Contains(out, "style: none")
 	assert.Contains(out, "template: CHANGELOG.tpl.md")
 	assert.Contains(out, "  repository_url: https://github.com/git-chglog/git-chglog/git-chglog")
-	assert.Contains(out, fmt.Sprintf("    pattern: \"%s\"", fmtGitBasic.Pattern))
+	assert.Contains(out, fmt.Sprintf("    pattern: \"%s\"", fmtGitBasic.pattern))
 	assert.Contains(out, fmt.Sprintf(
 		`    pattern_maps:
       - %s
       - %s`,
-		fmtGitBasic.PatternMaps[0],
-		fmtGitBasic.PatternMaps[1],
+		fmtGitBasic.patternMaps[0],
+		fmtGitBasic.patternMaps[1],
 	))
 }
 
@@ -39,8 +39,8 @@ func TestConfigBuliderEmptyRepoURL(t *testing.T) {
 	out, err := builder.Build(&Answer{
 		RepositoryURL:       "",
 		Style:               styleNone,
-		CommitMessageFormat: fmtGitBasic.Display,
-		Template:            tplStandard,
+		CommitMessageFormat: fmtGitBasic.display,
+		Template:            tplStandard.display,
 	})
 
 	assert.Nil(err)
@@ -55,7 +55,7 @@ func TestConfigBuliderInvalidFormat(t *testing.T) {
 		RepositoryURL:       "",
 		Style:               styleNone,
 		CommitMessageFormat: "",
-		Template:            tplStandard,
+		Template:            tplStandard.display,
 	})
 
 	assert.Contains(err.Error(), "invalid commit message format")

--- a/cmd/git-chglog/custom_template_builder.go
+++ b/cmd/git-chglog/custom_template_builder.go
@@ -58,13 +58,13 @@ func (*customTemplateBuilderImpl) versionHeader(style, template string) string {
 
 	// format
 	switch template {
-	case tplStandard:
+	case tplStandard.display:
 		tpl = fmt.Sprintf("%s## %s (%s)\n\n",
 			tpl,
 			tagName,
 			date,
 		)
-	case tplCool:
+	case tplCool.display:
 		tpl = fmt.Sprintf("%s## %s\n\n> %s\n\n",
 			tpl,
 			tagName,
@@ -82,13 +82,13 @@ func (*customTemplateBuilderImpl) commits(template, format string) string {
 	)
 
 	switch format {
-	case fmtSubject.Display:
+	case fmtSubject.display:
 		body = `{{ range .Commits -}}
 * {{ .Header }}
 {{ end }}`
 
 	default:
-		if format == fmtTypeScopeSubject.Display {
+		if format == fmtTypeScopeSubject.display {
 			header = "{{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}"
 		} else {
 			header = "{{ .Subject }}"

--- a/cmd/git-chglog/custom_template_builder_test.go
+++ b/cmd/git-chglog/custom_template_builder_test.go
@@ -12,8 +12,8 @@ func TestCustomTemplateBuilderDefault(t *testing.T) {
 
 	out, err := builder.Build(&Answer{
 		Style:               styleGitHub,
-		CommitMessageFormat: fmtTypeScopeSubject.Display,
-		Template:            tplStandard,
+		CommitMessageFormat: fmtTypeScopeSubject.display,
+		Template:            tplStandard.display,
 		IncludeMerges:       true,
 		IncludeReverts:      true,
 	})
@@ -65,8 +65,8 @@ func TestCustomTemplateBuilderNone(t *testing.T) {
 
 	out, err := builder.Build(&Answer{
 		Style:               styleNone,
-		CommitMessageFormat: fmtTypeScopeSubject.Display,
-		Template:            tplStandard,
+		CommitMessageFormat: fmtTypeScopeSubject.display,
+		Template:            tplStandard.display,
 		IncludeMerges:       true,
 		IncludeReverts:      true,
 	})
@@ -117,8 +117,8 @@ func TestCustomTemplateBuilderSubjectOnly(t *testing.T) {
 
 	out, err := builder.Build(&Answer{
 		Style:               styleNone,
-		CommitMessageFormat: fmtSubject.Display,
-		Template:            tplStandard,
+		CommitMessageFormat: fmtSubject.display,
+		Template:            tplStandard.display,
 		IncludeMerges:       true,
 		IncludeReverts:      true,
 	})
@@ -167,8 +167,8 @@ func TestCustomTemplateBuilderSubject(t *testing.T) {
 
 	out, err := builder.Build(&Answer{
 		Style:               styleNone,
-		CommitMessageFormat: fmtTypeSubject.Display,
-		Template:            tplStandard,
+		CommitMessageFormat: fmtTypeSubject.display,
+		Template:            tplStandard.display,
 		IncludeMerges:       true,
 		IncludeReverts:      true,
 	})
@@ -219,8 +219,8 @@ func TestCustomTemplateBuilderIgnoreReverts(t *testing.T) {
 
 	out, err := builder.Build(&Answer{
 		Style:               styleNone,
-		CommitMessageFormat: fmtTypeSubject.Display,
-		Template:            tplStandard,
+		CommitMessageFormat: fmtTypeSubject.display,
+		Template:            tplStandard.display,
 		IncludeMerges:       true,
 		IncludeReverts:      false,
 	})
@@ -263,8 +263,8 @@ func TestCustomTemplateBuilderIgnoreMerges(t *testing.T) {
 
 	out, err := builder.Build(&Answer{
 		Style:               styleNone,
-		CommitMessageFormat: fmtTypeSubject.Display,
-		Template:            tplStandard,
+		CommitMessageFormat: fmtTypeSubject.display,
+		Template:            tplStandard.display,
 		IncludeMerges:       false,
 		IncludeReverts:      true,
 	})
@@ -307,8 +307,8 @@ func TestCustomTemplateBuilderCool(t *testing.T) {
 
 	out, err := builder.Build(&Answer{
 		Style:               styleNone,
-		CommitMessageFormat: fmtTypeScopeSubject.Display,
-		Template:            tplCool,
+		CommitMessageFormat: fmtTypeScopeSubject.display,
+		Template:            tplCool.display,
 		IncludeMerges:       true,
 		IncludeReverts:      true,
 	})

--- a/cmd/git-chglog/kac_template_builder.go
+++ b/cmd/git-chglog/kac_template_builder.go
@@ -88,7 +88,7 @@ func (t *kacTemplateBuilderImpl) commits(commitGroups, format string) string {
 	)
 
 	switch format {
-	case fmtSubject.Display:
+	case fmtSubject.display:
 		body = `{{ range .Commits -}}
 - {{ .Header }}
 {{ end }}`

--- a/cmd/git-chglog/kac_template_builder_test.go
+++ b/cmd/git-chglog/kac_template_builder_test.go
@@ -12,8 +12,8 @@ func TestKACTemplateBuilderDefault(t *testing.T) {
 
 	out, err := builder.Build(&Answer{
 		Style:               styleGitHub,
-		CommitMessageFormat: fmtTypeScopeSubject.Display,
-		Template:            tplKeepAChangelog,
+		CommitMessageFormat: fmtTypeScopeSubject.display,
+		Template:            tplKeepAChangelog.display,
 		IncludeMerges:       true,
 		IncludeReverts:      true,
 	})
@@ -83,8 +83,8 @@ func TestKACTemplateBuilderNone(t *testing.T) {
 
 	out, err := builder.Build(&Answer{
 		Style:               styleNone,
-		CommitMessageFormat: fmtTypeScopeSubject.Display,
-		Template:            tplKeepAChangelog,
+		CommitMessageFormat: fmtTypeScopeSubject.display,
+		Template:            tplKeepAChangelog.display,
 		IncludeMerges:       true,
 		IncludeReverts:      true,
 	})
@@ -143,8 +143,8 @@ func TestKACTemplateBuilderSubject(t *testing.T) {
 
 	out, err := builder.Build(&Answer{
 		Style:               styleNone,
-		CommitMessageFormat: fmtSubject.Display,
-		Template:            tplKeepAChangelog,
+		CommitMessageFormat: fmtSubject.display,
+		Template:            tplKeepAChangelog.display,
 		IncludeMerges:       true,
 		IncludeReverts:      true,
 	})

--- a/cmd/git-chglog/template_builder.go
+++ b/cmd/git-chglog/template_builder.go
@@ -12,7 +12,7 @@ type TemplateBuilderFactory = func(string) TemplateBuilder
 
 func templateBuilderFactory(template string) TemplateBuilder {
 	switch template {
-	case tplKeepAChangelog:
+	case tplKeepAChangelog.display:
 		return NewKACTemplateBuilder()
 	default:
 		return NewCustomTemplateBuilder()

--- a/cmd/git-chglog/variables.go
+++ b/cmd/git-chglog/variables.go
@@ -5,6 +5,12 @@ import (
 	"strings"
 )
 
+// Previewable ...
+type Previewable interface {
+	Display() string
+	Preview() string
+}
+
 // Defaults
 var (
 	defaultConfigDir        = ".chglog"
@@ -28,22 +34,32 @@ var (
 
 // CommitMessageFormat ...
 type CommitMessageFormat struct {
-	Preview     string
-	Display     string
-	Pattern     string
-	PatternMaps []string
+	display     string
+	preview     string
+	pattern     string
+	patternMaps []string
+}
+
+// Display ...
+func (f *CommitMessageFormat) Display() string {
+	return f.display
+}
+
+// Preview ...
+func (f *CommitMessageFormat) Preview() string {
+	return f.preview
 }
 
 // PatternMapString ...
 func (f *CommitMessageFormat) PatternMapString() string {
 	s := " []"
-	l := len(f.PatternMaps)
+	l := len(f.patternMaps)
 	if l == 0 {
 		return s
 	}
 
 	arr := make([]string, l)
-	for i, p := range f.PatternMaps {
+	for i, p := range f.patternMaps {
 		arr[i] = fmt.Sprintf(
 			"%s- %s",
 			strings.Repeat(" ", 6),
@@ -57,30 +73,30 @@ func (f *CommitMessageFormat) PatternMapString() string {
 // Formats
 var (
 	fmtTypeScopeSubject = &CommitMessageFormat{
-		Preview:     "feat(core): Add new feature",
-		Display:     "<type>(<scope>): <subject>",
-		Pattern:     `^(\\w*)(?:\\(([\\w\\$\\.\\-\\*\\s]*)\\))?\\:\\s(.*)$`,
-		PatternMaps: []string{"Type", "Scope", "Subject"},
+		display:     "<type>(<scope>): <subject>",
+		preview:     "feat(core): Add new feature",
+		pattern:     `^(\\w*)(?:\\(([\\w\\$\\.\\-\\*\\s]*)\\))?\\:\\s(.*)$`,
+		patternMaps: []string{"Type", "Scope", "Subject"},
 	}
 	fmtTypeSubject = &CommitMessageFormat{
-		Preview:     "feat: Add new feature",
-		Display:     "<type>: <subject>",
-		Pattern:     `^(\\w*)\\:\\s(.*)$`,
-		PatternMaps: []string{"Type", "Subject"},
+		display:     "<type>: <subject>",
+		preview:     "feat: Add new feature",
+		pattern:     `^(\\w*)\\:\\s(.*)$`,
+		patternMaps: []string{"Type", "Subject"},
 	}
 	fmtGitBasic = &CommitMessageFormat{
-		Preview:     "Add new feature",
-		Display:     "<<type> subject>",
-		Pattern:     `^((\\w+)\\s.*)$`,
-		PatternMaps: []string{"Subject", "Type"},
+		display:     "<<type> subject>",
+		preview:     "Add new feature",
+		pattern:     `^((\\w+)\\s.*)$`,
+		patternMaps: []string{"Subject", "Type"},
 	}
 	fmtSubject = &CommitMessageFormat{
-		Preview:     "Add new feature (Not detect `type` field)",
-		Display:     "<subject>",
-		Pattern:     `^(.*)$`,
-		PatternMaps: []string{"Subject"},
+		display:     "<subject>",
+		preview:     "Add new feature (Not detect `type` field)",
+		pattern:     `^(.*)$`,
+		patternMaps: []string{"Subject"},
 	}
-	formats = []*CommitMessageFormat{
+	formats = []Previewable{
 		fmtTypeScopeSubject,
 		fmtTypeSubject,
 		fmtGitBasic,
@@ -88,12 +104,37 @@ var (
 	}
 )
 
+// TemplateStyleFormat ...
+type TemplateStyleFormat struct {
+	preview string
+	display string
+}
+
+// Display ...
+func (t *TemplateStyleFormat) Display() string {
+	return t.display
+}
+
+// Preview ...
+func (t *TemplateStyleFormat) Preview() string {
+	return t.preview
+}
+
 // Templates
 var (
-	tplKeepAChangelog = "keep-a-changelog"
-	tplStandard       = "standard"
-	tplCool           = "cool"
-	templates         = []string{
+	tplKeepAChangelog = &TemplateStyleFormat{
+		display: "keep-a-changelog",
+		preview: "https://github.com/git-chglog/example-type-scope-subject/blob/master/CHANGELOG.kac.md",
+	}
+	tplStandard = &TemplateStyleFormat{
+		display: "standard",
+		preview: "https://github.com/git-chglog/example-type-scope-subject/blob/master/CHANGELOG.standard.md",
+	}
+	tplCool = &TemplateStyleFormat{
+		display: "cool",
+		preview: "https://github.com/git-chglog/example-type-scope-subject/blob/master/CHANGELOG.cool.md",
+	}
+	templates = []Previewable{
 		tplKeepAChangelog,
 		tplStandard,
 		tplCool,

--- a/cmd/git-chglog/variables_test.go
+++ b/cmd/git-chglog/variables_test.go
@@ -10,7 +10,7 @@ func TestCommitMessageFormatPatternMaps(t *testing.T) {
 	assert := assert.New(t)
 
 	f := &CommitMessageFormat{
-		PatternMaps: []string{
+		patternMaps: []string{
 			"Type",
 			"Scope",
 			"Subject",
@@ -23,7 +23,7 @@ func TestCommitMessageFormatPatternMaps(t *testing.T) {
       - Subject`, f.PatternMapString())
 
 	f = &CommitMessageFormat{
-		PatternMaps: []string{},
+		patternMaps: []string{},
 	}
 
 	assert.Equal(" []", f.PatternMapString())


### PR DESCRIPTION
<!-- Thank you for your contribution to git-chglog! Please replace {Please write here} with your description -->


## What does this do / why do we need it?

Add URL of output example for template style.

```
? What is your favorite template style?
❯ keep-a-changelog -- https://github.com/git-chglog/example-type-scope-subject/blob/master/CHANGELOG.kac.md
  standard         -- https://github.com/git-chglog/example-type-scope-subject/blob/master/CHANGELOG.standard.md
  cool             -- https://github.com/git-chglog/example-type-scope-subject/blob/master/CHANGELOG.cool.md
```


## How this PR fixes the problem?

* None


## What should your reviewer look out for in this PR?

* None


## Check lists

* [x] Test passed
* [x] Coding style (indentation, etc)


## Additional Comments (if any)

* None


## Which issue(s) does this PR fix?

* None

<!--
fixes #
fixes #
-->
