### PR TITLE
fix: Panic occured when exec --next-tag with HEAD with tag

### DIFF
--- a/chglog.go
+++ b/chglog.go
@@ -195,7 +195,7 @@ func (gen *Generator) readVersions(tags []*Tag, first string) ([]*Version, error
 		})
 
 		// Instead of `getTags()`, assign the date to the tag
-		if isNext {
+		if isNext && len(commits) != 0 {
 			tag.Date = commits[0].Author.Date
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution to git-chglog! Please replace {Please write here} with your description -->


## What does this do / why do we need it?

don't access `commits[0]` when we can't find commits.


## How this PR fixes the problem?

check commits lenght.


## What should your reviewer look out for in this PR?

```
$ git commit -m foobar --allow-empty
$ git tag v1.0.0
$ git-chglog --next-tag 2.0.0 -o CHANGELOG.md
⌚️  Generating changelog ...
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/git-chglog/git-chglog.(*Generator).readVersions(0xc000086d00, 0xc00009b5c0, 0x3, 0x4, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/foobar/src/github.com/git-chglog/git-chglog/chglog.go:199 +0x827
github.com/git-chglog/git-chglog.(*Generator).Generate(0xc000086d00, 0x122e280, 0xc0000920a8, 0x0, 0x0, 0x0, 0x0)
```

## Check lists

* [X] Test passed
* [X] Coding style (indentation, etc)
