### PR TITLE
feat: add the contains, hasPrefix, hasSuffix, replace, lower and upper functions to Changelog template

### DIFF
--- a/chglog.go
+++ b/chglog.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"text/template"
 	"time"
 
@@ -302,8 +303,33 @@ func (gen *Generator) render(w io.Writer, unreleased *Unreleased, versions []*Ve
 	}
 
 	fmap := template.FuncMap{
+		// format the input time according to layout
 		"datetime": func(layout string, input time.Time) string {
 			return input.Format(layout)
+		},
+		// check whether substs is withing s
+		"contains": func(s, substr string) bool {
+			return strings.Contains(s, substr)
+		},
+		// check whether s begins with prefix
+		"hasPrefix": func(s, prefix string) bool {
+			return strings.HasPrefix(s, prefix)
+		},
+		// check whether s ends with suffix
+		"hasSuffix": func(s, suffix string) bool {
+			return strings.HasSuffix(s, suffix)
+		},
+		// replace the first n instances of old with new
+		"replace": func(s, old, new string, n int) string {
+			return strings.Replace(s, old, new, n)
+		},
+		// lower case a string
+		"lower": func(s string) string {
+			return strings.ToLower(s)
+		},
+		// upper case a string
+		"upper": func(s string) string {
+			return strings.ToUpper(s)
 		},
 	}
 


### PR DESCRIPTION
## What does this do / why do we need it?

This PR adds the strings.Contains, strings.HasPrefix, strings.HasSuffix, strings.Replace, strings.Lower and strings.Upper to the set of functions
available for usage in the changelog template.
The added functions can be used to manipulate commit messages before rendering the changelog.

## How this PR fixes the problem?

These new functions can be used, for example, to replace custom git commit markers (e.g. `[ci-skip]`) from the commit messages rendered to the changelog.
In addition, the `hasPrefix` and `hasSuffix` functions allow to easily filter out commits starting with a given prefix as described in https://github.com/git-chglog/git-chglog/issues/26 in situations where the commit messages are not always prefixed by a "chore" prefix. 

## What should your reviewer look out for in this PR?

The functions provided by the `strings` package and added in this PR to the `template.FuncMap` are named using a camel-case convention and starts with a lower-case first letter consistently with the already implemented `datetime`.
It is also be possible to adopt a different naming convention.

## Check lists

* [x] Test passed
* [ ] Coding style (indentation, etc)