### PR TITLE
add walk-by-refs

### DIFF
--- a/tag_reader.go
+++ b/tag_reader.go
@@ -22,6 +22,79 @@ func newTagReader(client gitcmd.Client) *tagReader {
 	}
 }
 
+func (r *tagReader) ReadRange(query string) ([]*Tag, error) {
+	// First get all of the tags and fetch the author / date
+	out, err := r.client.Exec(
+		"for-each-ref",
+		"--format",
+		"%(refname)"+r.separator+"%(subject)"+r.separator+"%(taggerdate)"+r.separator+"%(authordate)",
+		"refs/tags",
+	)
+
+	allTags := make(map[string]Tag)
+	desiredTags := []*Tag{}
+
+	if err != nil {
+		return desiredTags, fmt.Errorf("failed to get git-tag: %s", err.Error())
+	}
+
+	lines := strings.Split(out, "\n")
+
+	for _, line := range lines {
+		tokens := strings.Split(line, r.separator)
+
+		if len(tokens) != 4 {
+			continue
+		}
+
+		name := r.parseRefname(tokens[0])
+		subject := r.parseSubject(tokens[1])
+		date, err := r.parseDate(tokens[2])
+		if err != nil {
+			t, err2 := r.parseDate(tokens[3])
+			if err2 != nil {
+				return nil, err2
+			}
+			date = t
+		}
+
+		allTags[name] = Tag{
+			Name:    name,
+			Subject: subject,
+			Date:    date,
+		}
+	}
+
+	// after fetching all of the tags in the repo, walk the tree specified by the query
+	// i.e. `git log --pretty=%D --simplify-by-decoration RefA..RefB`
+
+	walkRefs, err := r.client.Exec(
+		"log",
+		"--pretty=%D",
+		"--simplify-by-decoration",
+		query)
+
+	lines2 := strings.Split(walkRefs, "\n")
+	for _, line2 := range lines2 {
+		tokens := strings.Split(line2, ",")
+
+		for _, observedRef := range tokens {
+			refTokens := strings.Split(observedRef, " ")
+			if refTokens[0] == "tag:" {
+				desiredTags = append(desiredTags, &Tag{
+					Date:    allTags[refTokens[1]].Date,
+					Name:    refTokens[1],
+					Subject: allTags[refTokens[1]].Subject,
+				})
+			}
+		}
+
+	}
+	r.assignPreviousAndNextTag(desiredTags)
+	return desiredTags, nil
+
+}
+
 func (r *tagReader) ReadAll() ([]*Tag, error) {
 	out, err := r.client.Exec(
 		"for-each-ref",


### PR DESCRIPTION
Adjusts the behavior of `getTags ` when a query is supplied in the CLI so that only `refs` in the queried lineage are rendered in the changelog

## What does this do / why do we need it?

Closes #32 

## How this PR fixes the problem?

First queries all refs in the project to establish creation date, *then* queries for refs in the requested lineage to produce an intersection of the two sets.

## What should your reviewer look out for in this PR?
There are no tests yet, and I'm not totally sure all of the changes are valid as I'm relatively new to Go

## Check lists

* [ ] Test passed
* [ ] Coding style (indentation, etc)


## Additional Comments (if any)

{Please write here}


## Which issue(s) does this PR fix?

Closes #32
