### PR TITLE
Fixing tests on Windows

### DIFF
--- a/chglog_test.go
+++ b/chglog_test.go
@@ -252,6 +252,7 @@ change message.`)
 
 	buf := &bytes.Buffer{}
 	err := gen.Generate(buf, "")
+	output := strings.Replace(strings.TrimSpace(buf.String()), "\r\n", "\n", -1)
 
 	assert.Nil(err)
 	assert.Equal(`<a name="unreleased"></a>
@@ -297,7 +298,7 @@ Online breaking change message.
 
 [Unreleased]: https://github.com/git-chglog/git-chglog/compare/2.0.0-beta.0...HEAD
 [2.0.0-beta.0]: https://github.com/git-chglog/git-chglog/compare/1.1.0...2.0.0-beta.0
-[1.1.0]: https://github.com/git-chglog/git-chglog/compare/1.0.0...1.1.0`, strings.TrimSpace(buf.String()))
+[1.1.0]: https://github.com/git-chglog/git-chglog/compare/1.0.0...1.1.0`, output)
 }
 
 func TestGeneratorWithNextTag(t *testing.T) {
@@ -346,6 +347,7 @@ func TestGeneratorWithNextTag(t *testing.T) {
 
 	buf := &bytes.Buffer{}
 	err := gen.Generate(buf, "")
+	output := strings.Replace(strings.TrimSpace(buf.String()), "\r\n", "\n", -1)
 
 	assert.Nil(err)
 	assert.Equal(`<a name="unreleased"></a>
@@ -372,10 +374,11 @@ func TestGeneratorWithNextTag(t *testing.T) {
 
 [Unreleased]: https://github.com/git-chglog/git-chglog/compare/3.0.0...HEAD
 [3.0.0]: https://github.com/git-chglog/git-chglog/compare/2.0.0...3.0.0
-[2.0.0]: https://github.com/git-chglog/git-chglog/compare/1.0.0...2.0.0`, strings.TrimSpace(buf.String()))
+[2.0.0]: https://github.com/git-chglog/git-chglog/compare/1.0.0...2.0.0`, output)
 
 	buf = &bytes.Buffer{}
 	err = gen.Generate(buf, "3.0.0")
+	output = strings.Replace(strings.TrimSpace(buf.String()), "\r\n", "\n", -1)
 
 	assert.Nil(err)
 	assert.Equal(`<a name="unreleased"></a>
@@ -389,5 +392,5 @@ func TestGeneratorWithNextTag(t *testing.T) {
 
 
 [Unreleased]: https://github.com/git-chglog/git-chglog/compare/3.0.0...HEAD
-[3.0.0]: https://github.com/git-chglog/git-chglog/compare/2.0.0...3.0.0`, strings.TrimSpace(buf.String()))
+[3.0.0]: https://github.com/git-chglog/git-chglog/compare/2.0.0...3.0.0`, output)
 }


### PR DESCRIPTION
I am using this package and was considering contributing to it.
I work on Windows and I noticed the tests don't all pass out of the box.

## What does this do / why do we need it?

The tests `TestGeneratorWithTypeScopeSubject` and `TestGeneratorWithNextTag` fail on Windows.

The markdown generated uses `\r\n` because I'm on windows. Even though I have `\r\n` locally in my go workspace because i have `core.autocrlf=true` in my git configuration. I believe the backtick string removes the `\r` in order for consistency.

```
--- FAIL: TestGeneratorWithTypeScopeSubject (1.65s)
        Error Trace:    chglog_test.go:257
        Error:          Not equal:
                        expected: "<a name=\"unreleased\"></a>\n## [Unreleased]\n\n### Bug Fixes\n- **core:** Fix commit\n\n\n<a name=\"2.0.0-beta.0\"></a>\n## [2.0.0-beta.0] - 2018-01-03\n### Features\n- **context:** Online breaking change\n- **router:** Muliple breaking change\n\n### BREAKING CHANGE\n\nMultiple\nbreaking\nchange message.\n\nOnline breaking change message.\n\n\n<a name=\"1.1.0\"></a>\n## [1.1.0] - 2018-01-02\n### Features\n- **parser:** New some super options #333\n\n### Reverts\n- feat(core): Add foo bar @mention and issue #987\n\n### Pull Requests\n- Merge pull request #1000 from tsuyoshiwada/patch-1\n- Merge pull request #999 from tsuyoshiwada/patch-1\n\n\n<a name=\"1.0.0\"></a>\n## 1.0.0 - 2018-01-01\n### Features\n- **core:** Add foo bar\n\n\n[Unreleased]: https://github.com/git-chglog/git-chglog/compare/2.0.0-beta.0...HEAD\n[2.0.0-beta.0]: https://github.com/git-chglog/git-chglog/compare/1.1.0...2.0.0-beta.0\n[1.1.0]: https://github.com/git-chglog/git-chglog/compare/1.0.0...1.1.0"
                        actual  : "<a name=\"unreleased\"></a>\r\n## [Unreleased]\r\n\r\n### Bug Fixes\r\n- **core:** Fix commit\r\n\r\n\r\n<a name=\"2.0.0-beta.0\"></a>\r\n## [2.0.0-beta.0] - 2018-01-03\r\n### Features\r\n- **context:** Online breaking change\r\n- **router:** Muliple breaking change\r\n\r\n### BREAKING CHANGE\r\n\r\nMultiple\nbreaking\nchange message.\r\n\r\nOnline breaking change message.\r\n\r\n\r\n<a name=\"1.1.0\"></a>\r\n## [1.1.0] - 2018-01-02\r\n### Features\r\n- **parser:** New some super options #333\r\n\r\n### Reverts\r\n- feat(core): Add foo bar @mention and issue #987\r\n\r\n### Pull Requests\r\n- Merge pull request #1000 from tsuyoshiwada/patch-1\r\n- Merge pull request #999 from tsuyoshiwada/patch-1\r\n\r\n\r\n<a name=\"1.0.0\"></a>\r\n## 1.0.0 - 2018-01-01\r\n### Features\r\n- **core:** Add foo bar\r\n\r\n\r\n[Unreleased]: https://github.com/git-chglog/git-chglog/compare/2.0.0-beta.0...HEAD\r\n[2.0.0-beta.0]: https://github.com/git-chglog/git-chglog/compare/1.1.0...2.0.0-beta.0\r\n[1.1.0]: https://github.com/git-chglog/git-chglog/compare/1.0.0...1.1.0"
        Test:           TestGeneratorWithTypeScopeSubject
=== RUN   TestGeneratorWithNextTag
--- FAIL: TestGeneratorWithNextTag (0.65s)
        Error Trace:    chglog_test.go:351
        Error:          Not equal:
                        expected: "<a name=\"unreleased\"></a>\n## [Unreleased]\n\n\n<a name=\"3.0.0\"></a>\n## [3.0.0] - 2018-03-01\n### Features\n- **core:** version 3.0.0\n\n\n<a name=\"2.0.0\"></a>\n## [2.0.0] - 2018-02-01\n### Features\n- **core:** version 2.0.0\n\n\n<a name=\"1.0.0\"></a>\n## 1.0.0 - 2018-01-01\n### Features\n- **core:** version 1.0.0\n\n\n[Unreleased]: https://github.com/git-chglog/git-chglog/compare/3.0.0...HEAD\n[3.0.0]: https://github.com/git-chglog/git-chglog/compare/2.0.0...3.0.0\n[2.0.0]: https://github.com/git-chglog/git-chglog/compare/1.0.0...2.0.0"
                        actual  : "<a name=\"unreleased\"></a>\r\n## [Unreleased]\r\n\r\n\r\n<a name=\"3.0.0\"></a>\r\n## [3.0.0] - 2018-03-01\r\n### Features\r\n- **core:** version 3.0.0\r\n\r\n\r\n<a name=\"2.0.0\"></a>\r\n## [2.0.0] - 2018-02-01\r\n### Features\r\n- **core:** version 2.0.0\r\n\r\n\r\n<a name=\"1.0.0\"></a>\r\n## 1.0.0 - 2018-01-01\r\n### Features\r\n- **core:** version 1.0.0\r\n\r\n\r\n[Unreleased]: https://github.com/git-chglog/git-chglog/compare/3.0.0...HEAD\r\n[3.0.0]: https://github.com/git-chglog/git-chglog/compare/2.0.0...3.0.0\r\n[2.0.0]: https://github.com/git-chglog/git-chglog/compare/1.0.0...2.0.0"
        Test:           TestGeneratorWithNextTag
        Error Trace:    chglog_test.go:381
        Error:          Not equal:
                        expected: "<a name=\"unreleased\"></a>\n## [Unreleased]\n\n\n<a name=\"3.0.0\"></a>\n## [3.0.0] - 2018-03-01\n### Features\n- **core:** version 3.0.0\n\n\n[Unreleased]: https://github.com/git-chglog/git-chglog/compare/3.0.0...HEAD\n[3.0.0]: https://github.com/git-chglog/git-chglog/compare/2.0.0...3.0.0"
                        actual  : "<a name=\"unreleased\"></a>\r\n## [Unreleased]\r\n\r\n\r\n<a name=\"3.0.0\"></a>\r\n## [3.0.0] - 2018-03-01\r\n### Features\r\n- **core:** version 3.0.0\r\n\r\n\r\n[Unreleased]: https://github.com/git-chglog/git-chglog/compare/3.0.0...HEAD\r\n[3.0.0]: https://github.com/git-chglog/git-chglog/compare/2.0.0...3.0.0"
        Test:           TestGeneratorWithNextTag
=
```

## How this PR fixes the problem?

By removing all `\r` from the generated string and comparing with the existing template string.

## What should your reviewer look out for in this PR?

That tests continue to work on a non-Windows platform.

## Check lists
- [ ] Test passed
- [ ] Coding style (indentation, etc)

## Additional Comments (if any)

## Which issue(s) does this PR fix?