### PR TITLE
feat: Add --tag-filter-pattern flag.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.dll
 *.so
 *.dylib
+git-chglog
 
 # Test binary, build with `go test -c`
 *.test
@@ -30,6 +31,10 @@ Icon
 
 # Thumbnails
 ._*
+
+# Intellij IDEA
+*.iml
+.idea
 
 # Files that might appear in the root of a volume
 .DocumentRevisions-V100

--- a/README.md
+++ b/README.md
@@ -166,15 +166,16 @@ USAGE:
     4. <name>       - Commit contained in <name>.
 
 OPTIONS:
-  --init                    generate the git-chglog configuration file in interactive
-  --config value, -c value  specifies a different configuration file to pick up (default: ".chglog/config.yml")
-  --output value, -o value  output path and filename for the changelogs. If not specified, output to stdout
-  --next-tag value          treat unreleased commits as specified tags (EXPERIMENTAL)
-  --silent                  disable stdout output
-  --no-color                disable color output [$NO_COLOR]
-  --no-emoji                disable emoji output [$NO_EMOJI]
-  --help, -h                show help
-  --version, -v             print the version
+  --init                                generate the git-chglog configuration file in interactive
+  --config value, -c value              specifies a different configuration file to pick up (default: ".chglog/config.yml")
+  --output value, -o value              output path and filename for the changelogs. If not specified, output to stdout
+  --next-tag value                      treat unreleased commits as specified tags (EXPERIMENTAL)
+  --silent                              disable stdout output
+  --no-color                            disable color output [$NO_COLOR]
+  --no-emoji                            disable emoji output [$NO_EMOJI]
+  --tag-filter-pattern value, -p value  regular expression of tag filter. Is specified, only matched tags will be picked
+  --help, -h                            show help
+  --version, -v                         print the version
 
 EXAMPLE:
 
@@ -512,7 +513,16 @@ See godoc [RenderData][doc-render-data] for available variables.
   This is a step that is necessary for project operation in many cases.
 </details>
 
-
+<details>
+  <summary>Can I generated CHANGELOG based on certain tags?</summary>
+  
+  Yes, it can be solved by use the `--tag-filter-pattern` flag.
+  
+  For example, the following command will only include tags starting with "v":
+  ```bash
+  $ git-chglog --tag-filter-pattern '^v'
+  ```
+</details>
 
 
 ## TODO

--- a/chglog.go
+++ b/chglog.go
@@ -18,6 +18,7 @@ import (
 type Options struct {
 	Processor            Processor
 	NextTag              string              // Treat unreleased commits as specified tags (EXPERIMENTAL)
+	TagFilterPattern     string              // Filter tag by regexp
 	CommitFilters        map[string][]string // Filter by using `Commit` properties and values. Filtering is not done by specifying an empty value
 	CommitSortBy         string              // Property name to use for sorting `Commit` (e.g. `Scope`)
 	CommitGroupBy        string              // Property name of `Commit` to be grouped into `CommitGroup` (e.g. `Type`)
@@ -108,7 +109,7 @@ func NewGenerator(config *Config) *Generator {
 	return &Generator{
 		client:          client,
 		config:          config,
-		tagReader:       newTagReader(client),
+		tagReader:       newTagReader(client, config.Options.TagFilterPattern),
 		tagSelector:     newTagSelector(),
 		commitParser:    newCommitParser(client, config),
 		commitExtractor: newCommitExtractor(config.Options),

--- a/cmd/git-chglog/config.go
+++ b/cmd/git-chglog/config.go
@@ -258,6 +258,7 @@ func (config *Config) Convert(ctx *CLIContext) *chglog.Config {
 		},
 		Options: &chglog.Options{
 			NextTag:              ctx.NextTag,
+			TagFilterPattern:     ctx.TagFilterPattern,
 			CommitFilters:        opts.Commits.Filters,
 			CommitSortBy:         opts.Commits.SortBy,
 			CommitGroupBy:        opts.CommitGroups.GroupBy,

--- a/cmd/git-chglog/context.go
+++ b/cmd/git-chglog/context.go
@@ -6,16 +6,17 @@ import (
 
 // CLIContext ...
 type CLIContext struct {
-	WorkingDir string
-	Stdout     io.Writer
-	Stderr     io.Writer
-	ConfigPath string
-	OutputPath string
-	Silent     bool
-	NoColor    bool
-	NoEmoji    bool
-	Query      string
-	NextTag    string
+	WorkingDir       string
+	Stdout           io.Writer
+	Stderr           io.Writer
+	ConfigPath       string
+	OutputPath       string
+	Silent           bool
+	NoColor          bool
+	NoEmoji          bool
+	Query            string
+	NextTag          string
+	TagFilterPattern string
 }
 
 // InitContext ...

--- a/cmd/git-chglog/main_test.go
+++ b/cmd/git-chglog/main_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli"
+	"testing"
+)
+
+var gAssert *assert.Assertions
+
+func mock_app_action(c *cli.Context) error {
+	assert := gAssert
+	assert.Equal("c.yml", c.String("config"))
+	assert.Equal("^v", c.String("tag-filter-pattern"))
+	assert.Equal("o.md", c.String("output"))
+	assert.Equal("v5", c.String("next-tag"))
+	assert.True(c.Bool("silent"))
+	assert.True(c.Bool("no-color"))
+	assert.True(c.Bool("no-emoji"))
+	return nil
+}
+
+func TestCreateApp(t *testing.T) {
+	assert := assert.New(t)
+	assert.True(true)
+	gAssert = assert
+
+	app := CreateApp(mock_app_action)
+	args := []string {
+		"git-chglog",
+		"--silent",
+		"--no-color",
+		"--no-emoji",
+		"--config", "c.yml",
+		"--output", "o.md",
+		"--next-tag", "v5",
+		"--tag-filter-pattern", "^v",
+	}
+	app.Run(args)
+}

--- a/tag_reader.go
+++ b/tag_reader.go
@@ -2,6 +2,7 @@ package chglog
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -13,12 +14,14 @@ type tagReader struct {
 	client    gitcmd.Client
 	format    string
 	separator string
+	reFilter  *regexp.Regexp
 }
 
-func newTagReader(client gitcmd.Client) *tagReader {
+func newTagReader(client gitcmd.Client, filterPattern string) *tagReader {
 	return &tagReader{
 		client:    client,
 		separator: "@@__CHGLOG__@@",
+		reFilter:  regexp.MustCompile(filterPattern),
 	}
 }
 
@@ -54,6 +57,12 @@ func (r *tagReader) ReadAll() ([]*Tag, error) {
 				return nil, err2
 			}
 			date = t
+		}
+
+		if r.reFilter != nil {
+			if !r.reFilter.MatchString(name) {
+				continue
+			}
 		}
 
 		tags = append(tags, &Tag{

--- a/tag_reader_test.go
+++ b/tag_reader_test.go
@@ -28,7 +28,7 @@ func TestTagReader(t *testing.T) {
 		},
 	}
 
-	actual, err := newTagReader(client).ReadAll()
+	actual, err := newTagReader(client, "").ReadAll()
 	assert.Nil(err)
 
 	assert.Equal(
@@ -102,5 +102,20 @@ func TestTagReader(t *testing.T) {
 			},
 		},
 		actual,
+	)
+
+	actual_filtered, err_filtered := newTagReader(client, "^v").ReadAll()
+	assert.Nil(err_filtered)
+	assert.Equal(
+		[]*Tag{
+			&Tag{
+				Name:    "v2.0.4-beta.1",
+				Subject: "Release v2.0.4-beta.1",
+				Date:    time.Date(2018, 2, 1, 0, 0, 0, 0, time.UTC),
+				Next: nil,
+				Previous: nil,
+			},
+		},
+		actual_filtered,
 	)
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to git-chglog! Please replace {Please write here} with your description -->


## What does this do / why do we need it?

Our project tags the git repo in many ways. Several CI pipeline will tag with different prefixes. But we only want to include certain tags in CHANGELOG.

## How this PR fixes the problem?

This PR adds a flag `--tag-filter-pattern`. This flag specifies a regular expression and only matched tags will be included in change log.

## What should your reviewer look out for in this PR?

Code change is tiny. No much special. The major change is in `tag_reader.go`.

## Check lists

* [x] Test passed
* [x] Coding style (indentation, etc)


## Additional Comments (if any)

NA

## Which issue(s) does this PR fix?

fixes #43

