### PR TITLE
feat: add option to filter commits in a case insensitive way

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ OPTIONS:
   --silent                              disable stdout output
   --no-color                            disable color output [$NO_COLOR]
   --no-emoji                            disable emoji output [$NO_EMOJI]
+  --no-case                             disable case sensitive filters
   --tag-filter-pattern value, -p value  regular expression of tag filter. Is specified, only matched tags will be picked
   --help, -h                            show help
   --version, -v                         print the version

--- a/chglog.go
+++ b/chglog.go
@@ -19,6 +19,7 @@ type Options struct {
 	Processor            Processor
 	NextTag              string              // Treat unreleased commits as specified tags (EXPERIMENTAL)
 	TagFilterPattern     string              // Filter tag by regexp
+	NoCaseSensitive      bool                // Filter commits in a case insensitive way
 	CommitFilters        map[string][]string // Filter by using `Commit` properties and values. Filtering is not done by specifying an empty value
 	CommitSortBy         string              // Property name to use for sorting `Commit` (e.g. `Scope`)
 	CommitGroupBy        string              // Property name of `Commit` to be grouped into `CommitGroup` (e.g. `Type`)

--- a/cmd/git-chglog/config.go
+++ b/cmd/git-chglog/config.go
@@ -259,6 +259,7 @@ func (config *Config) Convert(ctx *CLIContext) *chglog.Config {
 		Options: &chglog.Options{
 			NextTag:              ctx.NextTag,
 			TagFilterPattern:     ctx.TagFilterPattern,
+			NoCaseSensitive:      ctx.NoCaseSensitive,
 			CommitFilters:        opts.Commits.Filters,
 			CommitSortBy:         opts.Commits.SortBy,
 			CommitGroupBy:        opts.CommitGroups.GroupBy,

--- a/cmd/git-chglog/context.go
+++ b/cmd/git-chglog/context.go
@@ -14,6 +14,7 @@ type CLIContext struct {
 	Silent           bool
 	NoColor          bool
 	NoEmoji          bool
+	NoCaseSensitive  bool
 	Query            string
 	NextTag          string
 	TagFilterPattern string

--- a/cmd/git-chglog/main.go
+++ b/cmd/git-chglog/main.go
@@ -114,10 +114,16 @@ func CreateApp(actionFunc cli.ActionFunc) *cli.App {
 			EnvVar: "NO_EMOJI",
 		},
 
+		// no-case
+		cli.BoolFlag{
+			Name:   "no-case",
+			Usage:  "disable case sensitive filters",
+		},
+
 		// tag-filter-pattern
 		cli.StringFlag{
-			Name:   "tag-filter-pattern, p",
-			Usage:  "Regular expression of tag filter. Is specified, only matched tags will be picked",
+			Name:  "tag-filter-pattern, p",
+			Usage: "Regular expression of tag filter. Is specified, only matched tags will be picked",
 		},
 
 		// help & version
@@ -162,16 +168,17 @@ func AppAction(c *cli.Context) error {
 	// chglog
 	chglogCLI := NewCLI(
 		&CLIContext{
-			WorkingDir: wd,
-			Stdout:     colorable.NewColorableStdout(),
-			Stderr:     colorable.NewColorableStderr(),
-			ConfigPath: c.String("config"),
-			OutputPath: c.String("output"),
-			Silent:     c.Bool("silent"),
-			NoColor:    c.Bool("no-color"),
-			NoEmoji:    c.Bool("no-emoji"),
-			Query:      c.Args().First(),
-			NextTag:    c.String("next-tag"),
+			WorkingDir:       wd,
+			Stdout:           colorable.NewColorableStdout(),
+			Stderr:           colorable.NewColorableStderr(),
+			ConfigPath:       c.String("config"),
+			OutputPath:       c.String("output"),
+			Silent:           c.Bool("silent"),
+			NoColor:          c.Bool("no-color"),
+			NoEmoji:          c.Bool("no-emoji"),
+			NoCaseSensitive:  c.Bool("no-case"),
+			Query:            c.Args().First(),
+			NextTag:          c.String("next-tag"),
 			TagFilterPattern: c.String("tag-filter-pattern"),
 		},
 		fs,

--- a/cmd/git-chglog/main.go
+++ b/cmd/git-chglog/main.go
@@ -116,8 +116,8 @@ func CreateApp(actionFunc cli.ActionFunc) *cli.App {
 
 		// no-case
 		cli.BoolFlag{
-			Name:   "no-case",
-			Usage:  "disable case sensitive filters",
+			Name:  "no-case",
+			Usage: "disable case sensitive filters",
 		},
 
 		// tag-filter-pattern

--- a/cmd/git-chglog/main_test.go
+++ b/cmd/git-chglog/main_test.go
@@ -26,7 +26,7 @@ func TestCreateApp(t *testing.T) {
 	gAssert = assert
 
 	app := CreateApp(mock_app_action)
-	args := []string {
+	args := []string{
 		"git-chglog",
 		"--silent",
 		"--no-color",

--- a/cmd/git-chglog/variables.go
+++ b/cmd/git-chglog/variables.go
@@ -34,7 +34,7 @@ var (
 
 type typeSample struct {
 	typeName string
-	title string
+	title    string
 }
 
 // CommitMessageFormat ...
@@ -115,7 +115,7 @@ var (
 		patternMaps: []string{"Type", "Scope", "Subject"},
 		typeSamples: []typeSample{
 			{"feat", "Features"}, {"fix", "Bug Fixes"},
-			{"perf", "Performance Improvements"}, {"refactor", "Code Refactoring"},},
+			{"perf", "Performance Improvements"}, {"refactor", "Code Refactoring"}},
 	}
 	fmtTypeSubject = &CommitMessageFormat{
 		display:     "<type>: <subject>",
@@ -124,7 +124,7 @@ var (
 		patternMaps: []string{"Type", "Subject"},
 		typeSamples: []typeSample{
 			{"feat", "Features"}, {"fix", "Bug Fixes"},
-			{"perf", "Performance Improvements"}, {"refactor", "Code Refactoring"},},
+			{"perf", "Performance Improvements"}, {"refactor", "Code Refactoring"}},
 	}
 	fmtGitBasic = &CommitMessageFormat{
 		display:     "<<type> subject>",
@@ -133,7 +133,7 @@ var (
 		patternMaps: []string{"Subject", "Type"},
 		typeSamples: []typeSample{
 			{"feat", "Features"}, {"fix", "Bug Fixes"},
-			{"perf", "Performance Improvements"}, {"refactor", "Code Refactoring"},},
+			{"perf", "Performance Improvements"}, {"refactor", "Code Refactoring"}},
 	}
 	fmtSubject = &CommitMessageFormat{
 		display:     "<subject>",
@@ -149,7 +149,7 @@ var (
 		patternMaps: []string{"Type", "Subject"},
 		typeSamples: []typeSample{
 			{"sparkles", "Features"}, {"bug", "Bug Fixes"},
-			{"zap", "Performance Improvements"}, {"recycle", "Code Refactoring"},},
+			{"zap", "Performance Improvements"}, {"recycle", "Code Refactoring"}},
 	}
 	formats = []Previewable{
 		fmtTypeScopeSubject,

--- a/commit_extractor.go
+++ b/commit_extractor.go
@@ -21,7 +21,7 @@ func (e *commitExtractor) Extract(commits []*Commit) ([]*CommitGroup, []*Commit,
 	mergeCommits := []*Commit{}
 	revertCommits := []*Commit{}
 
-	filteredCommits := commitFilter(commits, e.opts.CommitFilters)
+	filteredCommits := commitFilter(commits, e.opts.CommitFilters, e.opts.NoCaseSensitive)
 
 	for _, commit := range commits {
 		if commit.Merge != nil {
@@ -37,7 +37,7 @@ func (e *commitExtractor) Extract(commits []*Commit) ([]*CommitGroup, []*Commit,
 
 	for _, commit := range filteredCommits {
 		if commit.Merge == nil && commit.Revert == nil {
-			e.processCommitGroups(&commitGroups, commit)
+			e.processCommitGroups(&commitGroups, commit, e.opts.NoCaseSensitive)
 		}
 
 		e.processNoteGroups(&noteGroups, commit)
@@ -49,14 +49,23 @@ func (e *commitExtractor) Extract(commits []*Commit) ([]*CommitGroup, []*Commit,
 	return commitGroups, mergeCommits, revertCommits, noteGroups
 }
 
-func (e *commitExtractor) processCommitGroups(groups *[]*CommitGroup, commit *Commit) {
+func (e *commitExtractor) processCommitGroups(groups *[]*CommitGroup, commit *Commit, noCaseSensitive bool) {
 	var group *CommitGroup
 
 	// commit group
 	raw, ttl := e.commitGroupTitle(commit)
 
 	for _, g := range *groups {
-		if g.RawTitle == raw {
+		rawTitleTmp := g.RawTitle
+		if noCaseSensitive {
+			rawTitleTmp = strings.ToLower(g.RawTitle)
+		}
+
+		rawTmp := raw
+		if noCaseSensitive {
+			rawTmp = strings.ToLower(raw)
+		}
+		if rawTitleTmp == rawTmp {
 			group = g
 		}
 	}

--- a/commit_filter.go
+++ b/commit_filter.go
@@ -1,6 +1,10 @@
 package chglog
 
-func commitFilter(commits []*Commit, filters map[string][]string) []*Commit {
+import (
+	"strings"
+)
+
+func commitFilter(commits []*Commit, filters map[string][]string, noCaseSensitive bool) []*Commit {
 	res := []*Commit{}
 
 	for _, commit := range commits {
@@ -23,9 +27,17 @@ func commitFilter(commits []*Commit, filters map[string][]string) []*Commit {
 				break
 			}
 
+			if noCaseSensitive {
+				str = strings.ToLower(str)
+			}
+
 			exist := false
 
 			for _, val := range values {
+				if noCaseSensitive {
+					val = strings.ToLower(val)
+				}
+
 				if str == val {
 					exist = true
 				}

--- a/commit_filter_test.go
+++ b/commit_filter_test.go
@@ -38,6 +38,11 @@ func TestCommitFilter(t *testing.T) {
 			Scope:   "fuga",
 			Subject: "4",
 		},
+		&Commit{
+			Type:    "Bar",
+			Scope:   "hogera",
+			Subject: "5",
+		},
 	}
 
 	assert.Equal(
@@ -46,8 +51,9 @@ func TestCommitFilter(t *testing.T) {
 			"2",
 			"3",
 			"4",
+			"5",
 		},
-		pickCommitSubjects(commitFilter(fixtures, map[string][]string{})),
+		pickCommitSubjects(commitFilter(fixtures, map[string][]string{}, false)),
 	)
 
 	assert.Equal(
@@ -59,7 +65,20 @@ func TestCommitFilter(t *testing.T) {
 		},
 		pickCommitSubjects(commitFilter(fixtures, map[string][]string{
 			"Type": {"foo", "bar"},
-		})),
+		}, false)),
+	)
+
+	assert.Equal(
+		[]string{
+			"1",
+			"2",
+			"3",
+			"4",
+			"5",
+		},
+		pickCommitSubjects(commitFilter(fixtures, map[string][]string{
+			"Type": {"foo", "bar"},
+		}, true)),
 	)
 
 	assert.Equal(
@@ -69,7 +88,7 @@ func TestCommitFilter(t *testing.T) {
 		},
 		pickCommitSubjects(commitFilter(fixtures, map[string][]string{
 			"Type": {"foo"},
-		})),
+		}, false)),
 	)
 
 	assert.Equal(
@@ -79,7 +98,18 @@ func TestCommitFilter(t *testing.T) {
 		},
 		pickCommitSubjects(commitFilter(fixtures, map[string][]string{
 			"Type": {"bar"},
-		})),
+		}, false)),
+	)
+
+	assert.Equal(
+		[]string{
+			"3",
+			"4",
+			"5",
+		},
+		pickCommitSubjects(commitFilter(fixtures, map[string][]string{
+			"Type": {"bar"},
+		}, true)),
 	)
 
 	assert.Equal(
@@ -89,7 +119,7 @@ func TestCommitFilter(t *testing.T) {
 		},
 		pickCommitSubjects(commitFilter(fixtures, map[string][]string{
 			"Scope": {"fuga"},
-		})),
+		}, false)),
 	)
 
 	assert.Equal(
@@ -99,7 +129,7 @@ func TestCommitFilter(t *testing.T) {
 		pickCommitSubjects(commitFilter(fixtures, map[string][]string{
 			"Type":  {"bar"},
 			"Scope": {"hoge"},
-		})),
+		}, false)),
 	)
 
 	assert.Equal(
@@ -110,6 +140,6 @@ func TestCommitFilter(t *testing.T) {
 		pickCommitSubjects(commitFilter(fixtures, map[string][]string{
 			"Type":  {"foo"},
 			"Scope": {"fuga", "hoge"},
-		})),
+		}, false)),
 	)
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to git-chglog! Please replace {Please write here} with your description -->


## What does this do / why do we need it?

I commited accidentally Improvement: Require kubernetes provider >=1.11.1 instead of improvement: Require kubernetes provider >=1.11.1 terraform-aws-modules/terraform-aws-eks@0c1ed0e. Then I found that there is no way to filter commits and map titles in a no case sensitive way.

It would be nice to add an option to enable or disable the case sensitive behavior on commits, commit_groups or notes.

## How this PR fixes the problem?

This PR add `commits.filter_insensitive` option to filter commits in a case insensitive way.

Maybe we should add `commits.filter_sensitive`, `commits.filter_case_sensitive` option or a cli flag instead ? @wadackel any thoughts ?

## Check lists

* [x] Test passed
* [x] Coding style (indentation, etc)

## Which issue(s) does this PR fix?

fixes https://github.com/git-chglog/git-chglog/issues/63
