### PR TITLE
feat: add upperFirst template function

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,96 +2,134 @@
 
 
 [[projects]]
+  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = "NUT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:7c4b5e23bb01e5945b0df8a5f181efa2d90abd19e368be7c7bd55a5737db0739"
   name = "github.com/fatih/color"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "507f6050b8568533fb3f5504de8e5205fa62a114"
   version = "v1.6.0"
 
 [[projects]]
+  digest = "1:cf327083982a19eae01f70be6663a935a02bac3a2dc79efbc19668c8378bfbb3"
   name = "github.com/imdario/mergo"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "163f41321a19dd09362d4c63cc2489db2015f1f4"
   version = "0.3.2"
 
 [[projects]]
+  digest = "1:08c231ec84231a7e23d67e4b58f975e1423695a32467a362ee55a803f9de8061"
   name = "github.com/mattn/go-colorable"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "167de6bfdfba052fa6b2d3664c8f5272e23c9072"
   version = "v0.0.9"
 
 [[projects]]
+  digest = "1:bc4f7eec3b7be8c6cb1f0af6c1e3333d5bb71072951aaaae2f05067b0803f287"
   name = "github.com/mattn/go-isatty"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
   version = "v0.0.3"
 
 [[projects]]
   branch = "master"
+  digest = "1:063d55b87e200bced5e2be658cc70acafb4c5bbc4afa04d4b82f66298b73d089"
   name = "github.com/mgutz/ansi"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "9520e82c474b0a04dd04f8a40959027271bab992"
 
 [[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = "NUT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:a852b1ad03ca063d2c57866d9f94dcb1cb2e111415c5902ce0586fc2d207221b"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
+  pruneopts = "NUT"
   revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
   version = "v1.2.1"
 
 [[projects]]
+  digest = "1:bc6fc3b838718f65a91d63108426e69bbddf643c04f20e2bbbb0ea907d84b984"
   name = "github.com/tsuyoshiwada/go-gitcmd"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "5f1f5f9475df211f8b48620d704284d7375229c3"
   version = "0.0.1"
 
 [[projects]]
+  digest = "1:5dba68a1600a235630e208cb7196b24e58fcbb77bb7a6bec08fcd23f081b0a58"
   name = "github.com/urfave/cli"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "cfb38830724cc34fedffe9a2a29fb54fa9169cd1"
   version = "v1.20.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:600bbc566231723dd6d13ccb6269a1c97235041281d796e03102ae4feab4d5d8"
   name = "golang.org/x/sys"
   packages = ["unix"]
+  pruneopts = "NUT"
   revision = "37707fdb30a5b38865cfb95e5aab41707daec7fd"
 
 [[projects]]
+  digest = "1:8f2948d3a161e4ef9591a3a465ef8fb94e12f458115ed00f9aed6c2c0a1d3025"
   name = "gopkg.in/AlecAivazis/survey.v1"
   packages = [
     ".",
     "core",
-    "terminal"
+    "terminal",
   ]
+  pruneopts = "NUT"
   revision = "9f89d9dd66613216993dc300f9f3dbae9c3c9bda"
   version = "v1.4.2"
 
 [[projects]]
+  digest = "1:e21bd8ae4721734a5b9a79c7345aa528f0cc2e0cc18265691c37566f1c445a19"
   name = "gopkg.in/kyokomi/emoji.v1"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "7e06b236c489543f53868841f188a294e3383eab"
   version = "v1.5"
 
 [[projects]]
   branch = "v2"
+  digest = "1:13e704c08924325be00f96e47e7efe0bfddf0913cdfc237423c83f9b183ff590"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "d670f9405373e636a5a2765eea47fac0c9bc91a4"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "da532fb70b3049dffe6ae9f73b3f0a742452639096a325ac5d2400be6ad0559e"
+  input-imports = [
+    "github.com/fatih/color",
+    "github.com/imdario/mergo",
+    "github.com/mattn/go-colorable",
+    "github.com/stretchr/testify/assert",
+    "github.com/tsuyoshiwada/go-gitcmd",
+    "github.com/urfave/cli",
+    "gopkg.in/AlecAivazis/survey.v1",
+    "gopkg.in/kyokomi/emoji.v1",
+    "gopkg.in/yaml.v2",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/chglog.go
+++ b/chglog.go
@@ -332,6 +332,13 @@ func (gen *Generator) render(w io.Writer, unreleased *Unreleased, versions []*Ve
 		"upper": func(s string) string {
 			return strings.ToUpper(s)
 		},
+		// upper case the first character of a string
+		"upperFirst": func(s string) string {
+			if len(s) > 0 {
+				return strings.ToUpper(string(s[0])) + s[1:]
+			}
+			return ""
+		},
 	}
 
 	fname := filepath.Base(gen.config.Template)

--- a/tag_reader_test.go
+++ b/tag_reader_test.go
@@ -109,10 +109,10 @@ func TestTagReader(t *testing.T) {
 	assert.Equal(
 		[]*Tag{
 			&Tag{
-				Name:    "v2.0.4-beta.1",
-				Subject: "Release v2.0.4-beta.1",
-				Date:    time.Date(2018, 2, 1, 0, 0, 0, 0, time.UTC),
-				Next: nil,
+				Name:     "v2.0.4-beta.1",
+				Subject:  "Release v2.0.4-beta.1",
+				Date:     time.Date(2018, 2, 1, 0, 0, 0, 0, time.UTC),
+				Next:     nil,
 				Previous: nil,
 			},
 		},


### PR DESCRIPTION
<!-- Thank you for your contribution to git-chglog! Please replace {Please write here} with your description -->


## What does this do / why do we need it?

Add `upperFirst` template function. This can be useful to print subjects (`{{ .Subject | upperFirst }}`) in changelog.

We'll get changelog like this whatever commits message started with capital letters or not.

FEATURES:
- Add support for additional volumes
- Add interpreter option to `wait_for_cluster_cmd`

## Check lists

* [x] Test passed
* [x] Coding style (indentation, etc)

