### PR TITLE
feat: add `--sort [TYPE]` flag 

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ OPTIONS:
   --jira-url value            Jira URL [$JIRA_URL]
   --jira-username value       Jira username [$JIRA_USERNAME]
   --jira-token value          Jira token [$JIRA_TOKEN]
+  --sort value                Specify how to sort tags; currently supports "date" or by "semver" (default: date)
   --help, -h                  show help (default: false)
   --version, -v               print the version (default: false)
 

--- a/cmd/git-chglog/config.go
+++ b/cmd/git-chglog/config.go
@@ -308,7 +308,7 @@ func (config *Config) Convert(ctx *CLIContext) *chglog.Config {
 		Options: &chglog.Options{
 			NextTag:                     ctx.NextTag,
 			TagFilterPattern:            ctx.TagFilterPattern,
-			Sort:                        opts.Sort,
+			Sort:                        orValue(ctx.Sort, opts.Sort),
 			NoCaseSensitive:             ctx.NoCaseSensitive,
 			Paths:                       ctx.Paths,
 			CommitFilters:               opts.Commits.Filters,

--- a/cmd/git-chglog/context.go
+++ b/cmd/git-chglog/context.go
@@ -24,6 +24,7 @@ type CLIContext struct {
 	JiraToken        string
 	JiraURL          string
 	Paths            []string
+	Sort             string
 }
 
 // InitContext ...

--- a/cmd/git-chglog/main.go
+++ b/cmd/git-chglog/main.go
@@ -178,6 +178,13 @@ func CreateApp(actionFunc cli.ActionFunc) *cli.App {
 			EnvVars: []string{"JIRA_TOKEN"},
 		},
 
+		// sort
+		&cli.StringFlag{
+			Name:        "sort",
+			Usage:       "Specify how to sort tags; currently supports \"date\" or by \"semver\"",
+			DefaultText: "date",
+		},
+
 		// help & version
 		cli.HelpFlag,
 		cli.VersionFlag,
@@ -240,6 +247,7 @@ func AppAction(c *cli.Context) error {
 			JiraToken:        c.String("jira-token"),
 			JiraURL:          c.String("jira-url"),
 			Paths:            c.StringSlice("path"),
+			Sort:             c.String("sort"),
 		},
 		fs,
 		NewConfigLoader(),


### PR DESCRIPTION
## What does this do / why do we need it?

First off, thank you for creating an awesome tool. We're using `git-chglog` in many open source repositories at New Relic and we would like to continue doing so.

~~The PR introduces **sorting tags by version number** instead of sorting by the date of tag creation. Users can still sort by date by passing the flag `--sort-by-date`. Using `--sort-by-date` will perform the original behavior of the `git-chglog` command.~~

Per request to integrate with the latest configuration updates from #124 (nice addition @ldelossa 🙂 ), this pull request introduces **sorting tags by semver version** using the `--sort [TYPE]` flag where `TYPE` is either `date` or `semver`.  Sort by date is still default behavior.

**Previous reasoning behind the idea:**
Since we support multiple major release branches of a repository, our CHANGELOG gets mangled when we release v1.x and then release an update for v2.x. Essentially the v1.x commits get combined with the v2.x commits in the CHANGELOG and requires manual editing that can be cumbersome with every new release we create. Sorting the tags by version number fixes this issue.

Give it a test drive:
```
make build
```
This will build the binaries for supported architectures located in the `./bin` directory- e.g. `./bin/{arch}/git-chglog` (replace `{arch}` with `darwin`, etc)

```
./bin/darwin/git-chglog
```

## How this PR fixes the problem?

Sorting the tags by version number ensures `git-chglog` selects the correct previous tag to compare to the new tag.

Current hypothetical ordering for a CHANGELOG might look like this:
```
v2.1.0 <-- will contain commit messages from v1.1.1 due to how git-chglog sorts from tag timestamp
v1.1.1 <-- patch release for v1.x (this causes an issue for all v2.x release after this one)
v2.0.0
v1.1.0
v1.0.0
```
This is because the diff that's being checked is `github.com/user/repo/compare/v1.1.1...v2.1.0`, but we need this to be `github.com/user/repo/compare/v2.0.0...v2.1.0` for the latest release in the example above.

This PR introduces ordering for a CHANGELOG that looks like this:
```
v2.1.0 
v2.0.0
v1.1.1 
v1.1.0
v1.0.0
```
This ensures the correct previous tag is selected for comparison to create the CHANGELOG entries. 

## What should your reviewer look out for in this PR?

This PR migrates this project from `dep` to [Go modules](https://blog.golang.org/migrating-to-go-modules). The `vendor` directory is no longer needed.


## Check lists

* [x] Test passed
* [x] Coding style (indentation, etc)


## Which issue(s) does this PR fix?
Resolves: #74
Resolves: #112 
