### PR TITLE
chore: Fix Makefile typo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ clean:
 	rm -rf $(GOPATH)/bin/git-chglog
 	rm -rf cover.out
 
-.PHONY: bulid
+.PHONY: build
 build:
 	go build -i -o git-chglog
 


### PR DESCRIPTION
<!-- Thank you for your contribution to git-chglog! Please replace {Please write here} with your description -->


## What does this do / why do we need it?

Fix typo in Makefile