### PR TITLE
feat: enable output to be JSON encoded

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ clean:
 	rm -rf $(GOPATH)/bin/git-chglog
 	rm -rf cover.out
 
-.PHONY: bulid
+.PHONY: build
 build:
 	go build -i -o git-chglog
 

--- a/cmd/git-chglog/config.go
+++ b/cmd/git-chglog/config.go
@@ -260,6 +260,7 @@ func (config *Config) Convert(ctx *CLIContext) *chglog.Config {
 			NextTag:              ctx.NextTag,
 			TagFilterPattern:     ctx.TagFilterPattern,
 			NoCaseSensitive:      ctx.NoCaseSensitive,
+			JsonOutput:						ctx.JsonOutput,
 			CommitFilters:        opts.Commits.Filters,
 			CommitSortBy:         opts.Commits.SortBy,
 			CommitGroupBy:        opts.CommitGroups.GroupBy,

--- a/cmd/git-chglog/context.go
+++ b/cmd/git-chglog/context.go
@@ -18,6 +18,7 @@ type CLIContext struct {
 	Query            string
 	NextTag          string
 	TagFilterPattern string
+	JsonOutput       bool
 }
 
 // InitContext ...

--- a/cmd/git-chglog/main.go
+++ b/cmd/git-chglog/main.go
@@ -47,6 +47,10 @@ func CreateApp(actionFunc cli.ActionFunc) *cli.App {
 
     The above is a command to generate CHANGELOG with the commit included in the latest tag.
 
+  $ {{.Name}} --json
+
+    The above is a command to output a JSON encooded string to standard output.
+
   $ {{.Name}} --output CHANGELOG.md
 
     The above is a command to output to CHANGELOG.md instead of standard output.
@@ -126,6 +130,12 @@ func CreateApp(actionFunc cli.ActionFunc) *cli.App {
 			Usage: "Regular expression of tag filter. Is specified, only matched tags will be picked",
 		},
 
+		// json
+		cli.BoolFlag{
+			Name:  "json",
+			Usage: "output a JSON encoded string of the changelog",
+		},
+
 		// help & version
 		cli.HelpFlag,
 		cli.VersionFlag,
@@ -180,6 +190,7 @@ func AppAction(c *cli.Context) error {
 			Query:            c.Args().First(),
 			NextTag:          c.String("next-tag"),
 			TagFilterPattern: c.String("tag-filter-pattern"),
+			JsonOutput:       c.Bool("json"),
 		},
 		fs,
 		NewConfigLoader(),


### PR DESCRIPTION
TL;DR - Adds a cli clag `--json` to output the changelog as a JSON encoded string.

## What does this do / why do we need it?

`git-chglog` is brilliant and outputs wonderfully formatted changelogs to STDOUT or a file... We'd like to start piping changelogs into MS Teams, Slack and other web APIs on release/deployment that only accept valid formatted JSON.

We _could_ use `sed`, `awk` etc... or write a python or ruby script to pipe output through but it might nice to be able to get a JSON sting back straight from `git-chglog`

## How this PR fixes the problem?

Allows the user to specify a cli flag: `--json` to get encoded JSON. 

## What should your reviewer look out for in this PR?

This is an initial commit, I still need to add:
- [ ] Tests
- [ ] Docs

and it's an early commit for discussion or closure if this feature isn't desirable.  

## Check lists

* [ ] Test passed
* [ ] Coding style (indentation, etc)
