### PR TITLE
chore(deps): add initial renovatebot configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,25 @@
+{
+  "semanticCommits": true,
+  "prHourlyLimit": 5,
+  "reviewersFromCodeOwners": true,
+  "labels": [
+    "dependencies"
+  ],
+  "extends": [
+    "config:base",
+    "group:allNonMajor"
+  ],
+  "postUpdateOptions": ["gomodTidy"],
+  "major": {
+    "labels": [
+      "dependencies",
+      "major"
+    ]
+  },
+  "minor": {
+    "labels": [
+      "dependencies",
+      "minor"
+    ]
+  }
+}


### PR DESCRIPTION
## What does this do / why do we need it?

This add the initial configuration for the [Renovate Bot](https://www.whitesourcesoftware.com/free-developer-tools/renovate)

What it does for a go project: https://docs.renovatebot.com/golang/
Configuration options (there's a lot of them): https://docs.renovatebot.com/configuration-options/

Discussion around renovate started in this thread: https://github.com/git-chglog/git-chglog/pull/93#issuecomment-776891825

>
> NOTE: We will need to have a repo Admin [Install the App within Github for the Repo](https://docs.renovatebot.com/install-github-app/). I am happy to do this, but I am not an Admin for the repo. 
>

## How this PR fixes the problem?

This will provide a consistent way to keep the project dependencies patched. Most importantly, as security patches are pushed to dependencies, we will get automatic notifications and PRs.

## What should your reviewer look out for in this PR?

Take a look at the docs for renovate listed below. 

What it does for a go project: https://docs.renovatebot.com/golang/
[`gomodTidy` post update option](https://docs.renovatebot.com/configuration-options/#postupdateoptions)

Also note that the [`group:allNonMajor`](https://docs.renovatebot.com/presets-group/#groupallnonmajor) option will rollup all minor and patch updates into a single PR. I have found this useful for mitigating noise PRs. 

Example of what that looks like in the wild: https://github.com/GoodwayGroup/gw-aws-audit/pull/40
![image](https://user-images.githubusercontent.com/1429775/109600076-10eb8480-7ae2-11eb-83db-e03ed5ac0bd5.png)

## Check lists

* [X] Test passed (N/A)
* [X] Coding style (indentation, etc)


## Additional Comments (if any)

{Please write here}


## Which issue(s) does this PR fix?

closes #93 