### PR TITLE
fix(deps): update module github.com/urfave/cli to v2

### DIFF
--- a/cmd/git-chglog/main.go
+++ b/cmd/git-chglog/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/mattn/go-colorable"
 	gitcmd "github.com/tsuyoshiwada/go-gitcmd"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 )
 
 func CreateApp(actionFunc cli.ActionFunc) *cli.App {
@@ -71,57 +71,57 @@ func CreateApp(actionFunc cli.ActionFunc) *cli.App {
 
 	app.Flags = []cli.Flag{
 		// init
-		cli.BoolFlag{
+		&cli.BoolFlag{
 			Name:  "init",
 			Usage: "generate the git-chglog configuration file in interactive",
 		},
 
 		// config
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name:  "config, c",
 			Usage: "specifies a different configuration file to pick up",
 			Value: ".chglog/config.yml",
 		},
 
 		// output
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name:  "output, o",
 			Usage: "output path and filename for the changelogs. If not specified, output to stdout",
 		},
 
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name:  "next-tag",
 			Usage: "treat unreleased commits as specified tags (EXPERIMENTAL)",
 		},
 
 		// silent
-		cli.BoolFlag{
+		&cli.BoolFlag{
 			Name:  "silent",
 			Usage: "disable stdout output",
 		},
 
 		// no-color
-		cli.BoolFlag{
+		&cli.BoolFlag{
 			Name:   "no-color",
 			Usage:  "disable color output",
-			EnvVar: "NO_COLOR",
+			EnvVars: []string{"NO_COLOR"},
 		},
 
 		// no-emoji
-		cli.BoolFlag{
+		&cli.BoolFlag{
 			Name:   "no-emoji",
 			Usage:  "disable emoji output",
-			EnvVar: "NO_EMOJI",
+			EnvVars: []string{"NO_EMOJI"},
 		},
 
 		// no-case
-		cli.BoolFlag{
+		&cli.BoolFlag{
 			Name:  "no-case",
 			Usage: "disable case sensitive filters",
 		},
 
 		// tag-filter-pattern
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name:  "tag-filter-pattern, p",
 			Usage: "Regular expression of tag filter. Is specified, only matched tags will be picked",
 		},

--- a/cmd/git-chglog/main_test.go
+++ b/cmd/git-chglog/main_test.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/stretchr/testify/assert"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 	"testing"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/mattn/go-colorable v0.1.8
 	github.com/stretchr/testify v1.7.0
 	github.com/tsuyoshiwada/go-gitcmd v0.0.0-20180205145712-5f1f5f9475df
-	github.com/urfave/cli v1.22.5
+	github.com/urfave/cli/v2 v2.3.0
 	gopkg.in/kyokomi/emoji.v1 v1.5.1
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tsuyoshiwada/go-gitcmd v0.0.0-20180205145712-5f1f5f9475df h1:Y2l28Jr3vOEeYtxfVbMtVfOdAwuUqWaP9fvNKiBVeXY=
 github.com/tsuyoshiwada/go-gitcmd v0.0.0-20180205145712-5f1f5f9475df/go.mod h1:pnyouUty/nBr/zm3GYwTIt+qFTLWbdjeLjZmJdzJOu8=
-github.com/urfave/cli v1.22.5 h1:lNq9sAHXK2qfdI8W+GRItjCEkI+2oR4d+MEHy1CKXoU=
-github.com/urfave/cli v1.22.5/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
+github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190530122614-20be4c3c3ed5 h1:8dUaAV7K4uHsF56JQWkprecIQKdPHtR9jCHF5nB8uzc=
 golang.org/x/crypto v0.0.0-20190530122614-20be4c3c3ed5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -57,7 +57,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/kyokomi/emoji.v1 v1.5.1 h1:beetH5mWDMzFznJ+Qzd5KVHp79YKhVUMcdO8LpRLeGw=
 gopkg.in/kyokomi/emoji.v1 v1.5.1/go.mod h1:N9AZ6hi1jHOPn34PsbpufQZUcKftSD7WgS2pgpmH4Lg=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=


### PR DESCRIPTION
## What does this do / why do we need it?

This PR updates the core CLI library we use ([urfave/cli](https://github.com/urfave/cli)) from v1 to v2.

> Migration guide https://github.com/urfave/cli/blob/master/docs/migrate-v1-to-v2.md 

## How this PR fixes the problem?

The [migration guide](https://github.com/urfave/cli/blob/master/docs/migrate-v1-to-v2.md) calls out the areas we would want to watch out for.

The biggest concern when migrating is the change that the library made to be more POSIX-compliant. They now enforce [Flags before args](https://github.com/urfave/cli/blob/master/docs/migrate-v1-to-v2.md#flags-before-args).

Luckily, the way `git-chglog` builds the `ActionFunc` means we do not have to worry about backwards compatibility moving forward with systems that use the tool within their CI. All actions are triggered via flags instead of delimited commands.

## What should your reviewer look out for in this PR?

The two areas we needed to change were with [](https://github.com/urfave/cli/blob/master/docs/migrate-v1-to-v2.md#envvar-is-now-a-list-envvars) and [CLI Flags as pointers](https://github.com/urfave/cli/blob/master/docs/migrate-v1-to-v2.md#cliflag-changed).

## Check lists

* [X] Test passed
* [X] Coding style (indentation, etc)

## Which issue(s) does this PR fix?

fixes #104
