### PR TITLE
fix(deps): update module gopkg.in/alecaivazis/survey.v1 to github.com/AlecAivazis/survey/v2

### DIFF
--- a/cmd/git-chglog/questioner.go
+++ b/cmd/git-chglog/questioner.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	gitcmd "github.com/tsuyoshiwada/go-gitcmd"
-	survey "gopkg.in/AlecAivazis/survey.v1"
+	survey "github.com/AlecAivazis/survey/v2"
 )
 
 // Answer ...

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,13 @@ module github.com/git-chglog/git-chglog
 go 1.15
 
 require (
+	github.com/AlecAivazis/survey/v2 v2.2.8
 	github.com/fatih/color v1.10.0
 	github.com/imdario/mergo v0.3.11
 	github.com/mattn/go-colorable v0.1.8
 	github.com/stretchr/testify v1.6.1
 	github.com/tsuyoshiwada/go-gitcmd v0.0.0-20180205145712-5f1f5f9475df
 	github.com/urfave/cli v1.22.5
-	gopkg.in/AlecAivazis/survey.v1 v1.8.8
 	gopkg.in/kyokomi/emoji.v1 v1.5.1
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
-github.com/AlecAivazis/survey/v2 v2.0.5/go.mod h1:WYBhg6f0y/fNYUuesWQc0PKbJcEliGcYHB9sNT3Bg74=
+github.com/AlecAivazis/survey/v2 v2.2.8 h1:TgxCwybKdBckmC+/P9/5h49rw/nAHe/itZL0dgHs+Q0=
+github.com/AlecAivazis/survey/v2 v2.2.8/go.mod h1:9DYvHgXtiXm6nCn+jXnOXLKbH+Yo9u8fAS/SduGdoPk=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8 h1:xzYJEypr/85nBpB11F9br+3HUrpgb+fcm5iADzXXYEw=
 github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8/go.mod h1:oX5x61PbNXchhh0oikYAH+4Pcfw5LKv21+Jnpr6r6Pc=
@@ -50,9 +51,8 @@ golang.org/x/sys v0.0.0-20190530182044-ad28b68e88f1/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae h1:/WDfKMnPU+m5M4xB+6x4kaepxRw6jWvR5iDRdvjHgy8=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-gopkg.in/AlecAivazis/survey.v1 v1.8.8 h1:5UtTowJZTz1j7NxVzDGKTz6Lm9IWm8DDF6b7a2wq9VY=
-gopkg.in/AlecAivazis/survey.v1 v1.8.8/go.mod h1:CaHjv79TCgAvXMSFJSVgonHXYWxnhzI3eoHtnX5UgUo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/kyokomi/emoji.v1 v1.5.1 h1:beetH5mWDMzFznJ+Qzd5KVHp79YKhVUMcdO8LpRLeGw=


### PR DESCRIPTION
## What does this do / why do we need it?

Update `gopkg.in/alecaivazis/survey` to current mainline version `github.com/AlecAivazis/survey/v2`.

This is used within the `--init` command.

## How this PR fixes the problem?

Updates the dependency location.

## What should your reviewer look out for in this PR?

There is no change in interface from `v1` to `v2` with the features that we use within the module.

## Check lists

* [X] Test passed
* [X] Coding style (indentation, etc)


## Additional Comments (if any)

There are currently no specific tests that exercise the `questioner.go` code. As a result, I did compile and test locally. Everything looked solid.

## Which issue(s) does this PR fix?

fixes #105 