### PR TITLE
fix(deps): update module gopkg.in/kyokomi/emoji.v1 to github.com/kyokomi/emoji/v2

### DIFF
--- a/cmd/git-chglog/logger.go
+++ b/cmd/git-chglog/logger.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 
 	"github.com/fatih/color"
-	emoji "gopkg.in/kyokomi/emoji.v1"
+	emoji "github.com/kyokomi/emoji/v2"
 )
 
 // Logger ...

--- a/cmd/git-chglog/logger_test.go
+++ b/cmd/git-chglog/logger_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
-	emoji "gopkg.in/kyokomi/emoji.v1"
+	emoji "github.com/kyokomi/emoji/v2"
 )
 
 func TestLoggerLogSilent(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,10 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.2.8
 	github.com/fatih/color v1.10.0
 	github.com/imdario/mergo v0.3.11
+	github.com/kyokomi/emoji/v2 v2.2.8
 	github.com/mattn/go-colorable v0.1.8
 	github.com/stretchr/testify v1.7.0
 	github.com/tsuyoshiwada/go-gitcmd v0.0.0-20180205145712-5f1f5f9475df
 	github.com/urfave/cli/v2 v2.3.0
-	gopkg.in/kyokomi/emoji.v1 v1.5.1
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNU
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kr/pty v1.1.4 h1:5Myjjh3JY/NaAi4IsUbHADytDyl1VE1Y9PXDlL+P/VQ=
 github.com/kr/pty v1.1.4/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kyokomi/emoji/v2 v2.2.8 h1:jcofPxjHWEkJtkIbcLHvZhxKgCPl6C7MyjTrD4KDqUE=
+github.com/kyokomi/emoji/v2 v2.2.8/go.mod h1:JUcn42DTdsXJo1SWanHh4HKDEyPaR5CqkmoirZZP9qE=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
@@ -55,8 +57,6 @@ golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/kyokomi/emoji.v1 v1.5.1 h1:beetH5mWDMzFznJ+Qzd5KVHp79YKhVUMcdO8LpRLeGw=
-gopkg.in/kyokomi/emoji.v1 v1.5.1/go.mod h1:N9AZ6hi1jHOPn34PsbpufQZUcKftSD7WgS2pgpmH4Lg=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=


### PR DESCRIPTION
## What does this do / why do we need it?

This will update the emoji module to v2 while addressing this install error:
```
go: gopkg.in/kyokomi/emoji.v2@v2.2.8: parsing go.mod:
	module declares its path as: github.com/kyokomi/emoji/v2
	        but was required as: gopkg.in/kyokomi/emoji.v2
```

## How this PR fixes the problem?

Use the desired `github.com/kyokomi/emoji/v2` module declaration.

## What should your reviewer look out for in this PR?

🍕 emoji 🥇 

## Check lists

* [X] Test passed
* [X] Coding style (indentation, etc)


## Additional Comments (if any)

Just trying to get these deps cleared to start looking at the more meaty stuff.


## Which issue(s) does this PR fix?

fixes #106 