### PR TITLE
fix(init): support OptionAnswer form in survey/v2

### DIFF
--- a/cmd/git-chglog/questioner.go
+++ b/cmd/git-chglog/questioner.go
@@ -81,8 +81,11 @@ func (q *questionerImpl) ask() (*Answer, error) {
 	tpls := q.getPreviewableList(templates)
 
 	var previewableTransform = func(ans interface{}) (newAns interface{}) {
-		if s, ok := ans.(string); ok {
-			newAns = q.parsePreviewableList(s)
+		if s, ok := ans.(survey.OptionAnswer); ok {
+			newAns = survey.OptionAnswer{
+				Value: q.parsePreviewableList(s.Value),
+				Index: s.Index,
+			}
 		}
 		return
 	}


### PR DESCRIPTION
## What does this do / why do we need it?

This is a hotfix for a bug identified in #111 and by @evanchaoli 

## How this PR fixes the problem?

Shout out to @evanchaoli for calling out the fix in https://github.com/git-chglog/git-chglog/pull/52

The update to `survey` v2 uses a new type `survey.OptionAnswer` with the Answer response, was previously `string`.

## What should your reviewer look out for in this PR?

The `questioner.go` file was the only place where I saw the `survey` module used. 

## Check lists

* [X] Test passed
* [X] Coding style (indentation, etc)

![image](https://user-images.githubusercontent.com/1429775/110380779-36b2e500-801e-11eb-8305-644214a231cb.png)


## Additional Comments (if any)

I missed this on the port to v2 in #108 Sorry for that.


## Which issue(s) does this PR fix?

fixes #111
refs #52 