### PR TITLE
fix(short flags): correctly define cli flags with shorthands

### DIFF
--- a/cmd/git-chglog/main.go
+++ b/cmd/git-chglog/main.go
@@ -89,13 +89,15 @@ func CreateApp(actionFunc cli.ActionFunc) *cli.App {
 		// config
 		&cli.StringFlag{
 			Name:  "config, c",
+			Aliases: []string{"c"},
 			Usage: "specifies a different configuration file to pick up",
 			Value: ".chglog/config.yml",
 		},
 
 		// template
 		&cli.StringFlag{
-			Name:  "template, t",
+			Name:  "template",
+			Aliases: []string{"t"},
 			Usage: "specifies a template file to pick up. If not specified, use the one in config",
 		},
 
@@ -107,7 +109,8 @@ func CreateApp(actionFunc cli.ActionFunc) *cli.App {
 
 		// output
 		&cli.StringFlag{
-			Name:  "output, o",
+			Name:  "output",
+			Aliases: []string{"o"},
 			Usage: "output path and filename for the changelogs. If not specified, output to stdout",
 		},
 


### PR DESCRIPTION
## What does this do / why do we need it?

This fixes the `BREAKING CHANGE` bug reported in #116

## How this PR fixes the problem?

This correctly defines the aliases for the CLI flags as needed with the update to `urfave/cli` v2.

![image](https://user-images.githubusercontent.com/1429775/110995927-bf909000-8340-11eb-9c3c-1ce35e5d8491.png)


## Check lists

* [x] Test passed
* [x] Coding style (indentation, etc)

## Which issue(s) does this PR fix?

fixes #116