### PR TITLE
chore: bump golang to 1.16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Run tests
         run: |
           make test

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,11 +16,10 @@ builds:
       - windows
       - darwin
     goarch:
+      - 386
       - amd64
       - arm
       - arm64
-    goarm:
-      - 6
 
 archives:
   - format_overrides:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@
   - [Templates](#templates)
   - [Supported Styles](#supported-styles)
   - [Jira Integration](#jira-integration)
+      - [1. Change the header parse pattern to recognize Jira issue id in the configure file.](#1-change-the-header-parse-pattern-to-recognize-jira-issue-id-in-the-configure-file)
+      - [2. Add Jira configuration to the configure file.](#2-add-jira-configuration-to-the-configure-file)
+      - [3. Update the template to show Jira data.](#3-update-the-template-to-show-jira-data)
   - [FAQ](#faq)
   - [TODO](#todo)
   - [Thanks](#thanks)
@@ -639,6 +642,7 @@ We alway welcome your contributions :clap:
 
 ### Development
 
+1. Use Golang version `>= 1.16`
 1. Fork (https://github.com/git-chglog/git-chglog) :tada:
 1. Create a feature branch :coffee:
 1. Run test suite with the `$ make test` command and confirm that it passes :zap:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/git-chglog/git-chglog
 
-go 1.15
+go 1.16
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.9


### PR DESCRIPTION
<!-- Thank you for your contribution to git-chglog! Please replace {Please write here} with your description -->


## What does this do / why do we need it?

I want to support `Darwin arm` builds


## How this PR fixes the problem?

- bumps to golang `1.16`
- uses `goreleaser` version [>=0.157.0](https://github.com/goreleaser/goreleaser/releases/tag/v0.157.0) , which the gh action does


## What should your reviewer look out for in this PR?

If I missed maybe something :)


## Check lists

* [x] Test passed
* [x] Coding style (indentation, etc)
* [x] Release step tested via `curl -sL https://git.io/goreleaser | bash -s -- --rm-dist --skip-publish --snapshot` 

