### PR TITLE
feat: add support for rendering .Body after .Subject as part of list

### DIFF
--- a/chglog.go
+++ b/chglog.go
@@ -343,6 +343,14 @@ func (gen *Generator) render(w io.Writer, unreleased *Unreleased, versions []*Ve
 			}
 			return ""
 		},
+		// indent all lines of s n spaces
+		"indent": func(s string, n int) string {
+			if len(s) == 0 {
+				return ""
+			}
+			pad := strings.Repeat(" ", n)
+			return pad + strings.ReplaceAll(s, "\n", "\n"+pad)
+		},
 	}
 
 	fname := filepath.Base(gen.config.Template)

--- a/commit_parser_test.go
+++ b/commit_parser_test.go
@@ -103,13 +103,14 @@ func TestCommitParserParse(t *testing.T) {
 					Source: "",
 				},
 			},
-			Notes:    []*Note{},
-			Mentions: []string{},
-			Header:   "feat(*): Add new feature #123",
-			Type:     "feat",
-			Scope:    "*",
-			Subject:  "Add new feature #123",
-			Body:     "",
+			Notes:       []*Note{},
+			Mentions:    []string{},
+			Header:      "feat(*): Add new feature #123",
+			Type:        "feat",
+			Scope:       "*",
+			Subject:     "Add new feature #123",
+			Body:        "",
+			TrimmedBody: "",
 		},
 		{
 			Hash: &Hash{
@@ -166,6 +167,7 @@ Fixes #3
 Closes #1
 
 BREAKING CHANGE: This is breaking point message.`,
+			TrimmedBody: `This is body message.`,
 		},
 		{
 			Hash: &Hash{
@@ -200,6 +202,7 @@ BREAKING CHANGE: This is breaking point message.`,
 @tsuyoshiwada
 @hogefuga
 @FooBarBaz`,
+			TrimmedBody: `Has mention body`,
 		},
 		{
 			Hash: &Hash{
@@ -280,6 +283,7 @@ class MyController extends Controller {
 
 Fixes #123
 Closes username/repository#456`, "```", "```"),
+			TrimmedBody: `This mixed body message.`,
 		},
 		{
 			Hash: &Hash{
@@ -300,14 +304,15 @@ Closes username/repository#456`, "```", "```"),
 			Revert: &Revert{
 				Header: "fix(core): commit message",
 			},
-			Refs:     []*Ref{},
-			Notes:    []*Note{},
-			Mentions: []string{},
-			Header:   "Revert \"fix(core): commit message\"",
-			Type:     "",
-			Scope:    "",
-			Subject:  "",
-			Body:     "This reverts commit f755db78dcdf461dc42e709b3ab728ceba353d1d.",
+			Refs:        []*Ref{},
+			Notes:       []*Note{},
+			Mentions:    []string{},
+			Header:      "Revert \"fix(core): commit message\"",
+			Type:        "",
+			Scope:       "",
+			Subject:     "",
+			Body:        "This reverts commit f755db78dcdf461dc42e709b3ab728ceba353d1d.",
+			TrimmedBody: "This reverts commit f755db78dcdf461dc42e709b3ab728ceba353d1d.",
 		},
 	}, commits)
 }

--- a/fields.go
+++ b/fields.go
@@ -8,6 +8,12 @@ type Hash struct {
 	Short string
 }
 
+// Contact of co-authors and signers
+type Contact struct {
+	Name  string
+	Email string
+}
+
 // Author of commit
 type Author struct {
 	Name  string
@@ -70,6 +76,8 @@ type Commit struct {
 	Refs        []*Ref
 	Notes       []*Note
 	Mentions    []string   // Name of the user included in the commit header or body
+	CoAuthors   []Contact  // (e.g. `Co-authored-by: user <user@email>`)
+	Signers     []Contact  // (e.g. `Signed-off-by: user <user@email>`)
 	JiraIssue   *JiraIssue // If no issue id found in header, `nil` is assigned
 	Header      string     // (e.g. `feat(core)[RNWY-310]: Add new feature`)
 	Type        string     // (e.g. `feat`)
@@ -77,6 +85,7 @@ type Commit struct {
 	Subject     string     // (e.g. `Add new feature`)
 	JiraIssueID string     // (e.g. `RNWY-310`)
 	Body        string
+	TrimmedBody string // Body without any Notes/Refs/Mentions/CoAuthors/Signers
 }
 
 // CommitGroup is a collection of commits grouped according to the `CommitGroupBy` option

--- a/testdata/trimmed_body.md
+++ b/testdata/trimmed_body.md
@@ -1,0 +1,48 @@
+{{ if .Versions -}}
+<a name="unreleased"></a>
+## [Unreleased]
+
+{{ if .Unreleased.CommitGroups -}}
+{{ range .Unreleased.CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ if .TrimmedBody -}}
+{{ indent .TrimmedBody 2 }}
+{{ end -}}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{ range .Versions }}
+<a name="{{ .Tag.Name }}"></a>
+## {{ if .Tag.Previous }}[{{ .Tag.Name }}]{{ else }}{{ .Tag.Name }}{{ end }} - {{ datetime "2006-01-02" .Tag.Date }}
+{{ range .CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ if .TrimmedBody -}}
+{{ indent .TrimmedBody 2 }}
+{{ end -}}
+{{ end }}
+{{ end -}}
+
+{{- if .NoteGroups -}}
+{{ range .NoteGroups -}}
+### {{ .Title }}
+{{ range .Notes }}
+{{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{- if .Versions }}
+[Unreleased]: {{ .Info.RepositoryURL }}/compare/{{ $latest := index .Versions 0 }}{{ $latest.Tag.Name }}...HEAD
+{{ range .Versions -}}
+{{ if .Tag.Previous -}}
+[{{ .Tag.Name }}]: {{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}
+{{ end -}}
+{{ end -}}
+{{ end -}}


### PR DESCRIPTION
## What does this do / why do we need it?

When attempting to render a commit body below the summary line of the commit there are two problems:

1) The text needs to be indented two spaces to appear as part of the list.
2) Notes (e.g. BREAKING CHANGE) are included in the body and end up being repeating in a Notes section (if this is part of your template).

Users that want verbose changelogs will want the body of the commit to render as part of the unordered list element of the header.

## How this PR fixes the problem?

To address 1 add an `indent` func to the template parsing.
To address 2 add a `TrimmedBody` to the `Commit` fields.

The `TrimmedBody` will include everything in `Body` but not any `Ref`s, `Note`s, or `Mention`s.

With both of these a template block like:

```
{{ if .TrimmedBody -}}
{{ indent .TrimmedBody 2 }}
{{ end -}}
```

Will render the trimmed down body section as intended.

## What should your reviewer look out for in this PR?

## Check lists

* [x] Test passed
* [x] Coding style (indentation, etc)

## Additional Comments (if any)

Both `commit_parser_test.go` and `fields.go` have whitespace diffs due to running gofmt. The actual diff on both is small.

## Which issue(s) does this PR fix?

none
