### PR TITLE
chore: use ldflags to pass version to build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+VERSION?=$$(git describe --tags --always)
+
+LDFLAGS="-X main.version=$(VERSION)"
+
 .PHONY: clean
 clean:
 	rm -rf ./dist/
@@ -7,7 +11,7 @@ clean:
 
 .PHONY: build
 build:
-	go build -o git-chglog ./cmd/git-chglog
+	go build -ldflags=$(LDFLAGS) -o git-chglog ./cmd/git-chglog
 
 .PHONY: test
 test:

--- a/cmd/git-chglog/main.go
+++ b/cmd/git-chglog/main.go
@@ -12,6 +12,9 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+// version is passed in via LDFLAGS main.version
+var version string
+
 // CreateApp creates and initializes CLI application
 // with description, flags, version, etc.
 func CreateApp(actionFunc cli.ActionFunc) *cli.App {
@@ -74,7 +77,7 @@ func CreateApp(actionFunc cli.ActionFunc) *cli.App {
 	app := cli.NewApp()
 	app.Name = "git-chglog"
 	app.Usage = "todo usage for git-chglog"
-	app.Version = Version
+	app.Version = version
 
 	app.Flags = []cli.Flag{
 		// init

--- a/cmd/git-chglog/version.go
+++ b/cmd/git-chglog/version.go
@@ -1,4 +1,0 @@
-package main
-
-// Version of git-chglog cli client
-const Version = "v0.12.0"


### PR DESCRIPTION
## What does this do / why do we need it?

This PR allows the build process to pass the `ldflags` parameter to the build to set the version based on tag. This is the first step for addressing #90. 

```
go build -ldflags=all="-X main.version=$(git describe --tags --always)" -o git-chglog ./cmd/git-chglog
```

## How this PR fixes the problem?

- `make build` has been updated to generate the `main.version` value for a local build.
    ![image](https://user-images.githubusercontent.com/1429775/112143676-38e07c00-8ba6-11eb-80b7-ee7cb016b72e.png)

- [GoReleaser](https://goreleaser.com/environment/#using-the-mainversion) supports passing the `main.version` flag by default, so our release process is covered.
    ![image](https://user-images.githubusercontent.com/1429775/112143743-4b5ab580-8ba6-11eb-9f62-afb3148599b7.png)

## Check lists

* [x] Test passed
* [x] Coding style (indentation, etc)


## Which issue(s) does this PR fix?

related #90 