### PR TITLE
chore: add make release target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,10 @@ changelog: build
 .PHONY: lint
 lint:
 	@golangci-lint run
+
+.PHONY: release
+release: changelog
+	@git add CHANGELOG.md
+	@git commit -m "chore: update changelog for $(VERSION)"
+	git tag $(VERSION)
+	git push origin master $(VERSION)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 [![godoc.org](https://img.shields.io/badge/godoc-reference-blue.svg?style=flat-square)](https://godoc.org/github.com/git-chglog/git-chglog)
 [![Actions Status](https://github.com/git-chglog/git-chglog/workflows/tests/badge.svg)](https://github.com/git-chglog/git-chglog/actions)
-[![AppVeyor](https://img.shields.io/appveyor/ci/tsuyoshiwada/git-chglog/master.svg?style=flat-square)](https://ci.appveyor.com/project/tsuyoshiwada/git-chglog/branch/master)
 [![Coverage Status](https://img.shields.io/coveralls/github/git-chglog/git-chglog.svg?style=flat-square)](https://coveralls.io/github/git-chglog/git-chglog?branch=master)
 [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/git-chglog/git-chglog/blob/master/LICENSE)
 
@@ -659,7 +658,7 @@ Within a `Commit`, the following Jira data can be used in template:
 
 We alway welcome your contributions :clap:
 
-### Development
+## Development
 
 1. Use Golang version `>= 1.16`
 1. Fork (https://github.com/git-chglog/git-chglog) :tada:
@@ -673,7 +672,24 @@ We alway welcome your contributions :clap:
 
 Bugs, feature requests and comments are more than welcome in the [issues].
 
-### Feedback
+## Release Process
+
+There is a `release` target within the Makefile that wraps up the steps to
+release a new version.
+
+> NOTE: Pass the `VERSION` variable when running the command to properly set
+> the tag version for the release.
+
+```bash
+$ VERSION=vX.Y.Z make release
+# EXAMPLE:
+$ VERSION=v0.11.3 make release
+```
+
+Once the `tag` has been pushed, the `goreleaser` github action will take care
+of the rest.
+
+## Feedback
 
 I would like to make `git-chglog` a better tool.
 The goal is to be able to use in various projects.


### PR DESCRIPTION
## What does this do / why do we need it?

This adds the `make release` target command. The command is dependent on the `changelog` target completing correctly.

It will:
1. Build the local copy of `git-chglog`
1. Update the `CHANGELOG`
1. Commit the changes
1. Tag the current HEAD
1. Push the `master` and `tag`

I broke down the steps to address #90 into these separate PRs over the last few days because I wanted to discuss each piece of work in isolation. This last piece is one where I think we need to be in alignment about what the automation should do.

## How this PR fixes the problem?

This "does the job" of removing the the manual steps by wrapping them up in a single command.

## What should your reviewer look out for in this PR?

How do we feel about the command pushing the tag and branch?

Do we want to have the push of the `tag` and `master` be a manual process?

## Check lists

* [ ] Test passed
* [ ] Coding style (indentation, etc)


## Additional Comments (if any)

Just to put this out there, I have used an alternative pattern that employs [workflow_dispatch](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/) to allow a Collaborator to trigger a release manually in Github Actions. See example: https://github.com/GoodwayGroup/lib-hapi-good-tracer/blob/main/.github/workflows/version.yml

There are some catches with this pattern, mainly that a tag pushed from an Action does not trigger other actions that are supposed to trigger on tag push. As a result I have found that a monolithic Action works best. It is easier to rollback if there is an issue. 

## Which issue(s) does this PR fix?

fixes #90 
