### PR TITLE
chore: add docker target to Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
 
 env:
   GO_VERSION: "1.16"
+  GOLANGCI_VERSION: "v1.38"
 
 jobs:
   tests:
@@ -54,4 +55,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.38
+          version: ${{ env.GOLANGCI_VERSION }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: publish
 
 on:
   push:
-    branches:    
+    branches:
       - master
 
 env:
@@ -10,26 +10,26 @@ env:
   DOCKER_REGISTRY: "quay.io"
 
 jobs:
-  goreleaser:
+  docker:
     runs-on: ubuntu-20.04
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
-      - name: Build go binary
-        run: make build
-      - name: Login to GitHub Packages Docker Registry
+
+      - name: Login to Docker Registry
         uses: docker/login-action@v1
         with:
           registry: ${{ env.DOCKER_REGISTRY }}
           username: ${{ secrets.QUAY_IO_USER }}
           password: ${{ secrets.QUAY_IO_TOKEN }}
+
       - name: Build and Push docker image
-        run: |
-          docker build --pull --tag ${{ env.DOCKER_REGISTRY }}/git-chglog/git-chglog:edge .
-          docker push ${{ env.DOCKER_REGISTRY }}/git-chglog/git-chglog:edge
+        run: DOCKER_TAG=edge make docker push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,13 +23,14 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
-      - name: Login to GitHub Packages Docker Registry
+
+      - name: Login to Docker Registry
         uses: docker/login-action@v1
         with:
           registry: ${{ env.DOCKER_REGISTRY }}
           username: ${{ secrets.QUAY_IO_USER }}
           password: ${{ secrets.QUAY_IO_TOKEN }}
-          
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,11 @@ GOHOST  ?= GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO)
 
 LDFLAGS ?= "-X main.version=$(VERSION)"
 
+# Docker variables
+DEFAULT_TAG  ?= $(shell echo "$(VERSION)" | tr -d 'v')
+DOCKER_IMAGE := quay.io/git-chglog/git-chglog
+DOCKER_TAG   ?= $(DEFAULT_TAG)
+
 .PHONY: all
 all: help
 
@@ -46,6 +51,16 @@ install:   ## Install git-chglog
 	@ $(MAKE) --no-print-directory log-$@
 	$(GOHOST) install ./cmd/git-chglog
 
+.PHONY: docker
+docker: build   ## Build Docker image
+	@ $(MAKE) --no-print-directory log-$@
+	docker build --pull --tag $(DOCKER_IMAGE):$(DOCKER_TAG) .
+
+.PHONY: push
+push:   ## Push Docker image
+	@ $(MAKE) --no-print-directory log-$@
+	docker push $(DOCKER_IMAGE):$(DOCKER_TAG)
+
 ###########
 ##@ Release
 
@@ -55,7 +70,7 @@ changelog: build   ## Generate changelog
 	./git-chglog --next-tag $(VERSION) -o CHANGELOG.md
 
 .PHONY: release
-release: changelog    ## Release a new tag
+release: changelog   ## Release a new tag
 	@ $(MAKE) --no-print-directory log-$@
 	git add CHANGELOG.md
 	git commit -m "chore: update changelog for $(VERSION)"


### PR DESCRIPTION
<!-- Thank you for your contribution to git-chglog! Please replace {Please write here} with your description -->


## What does this do / why do we need it?

Following up #135, adding two new targets to Makefile:

- `docker`: Build Docker image
- `push`: Push Docker image

## Check lists

* [x] Test passed
* [x] Coding style (indentation, etc)

## Which issue(s) does this PR fix?

Fixes #137