### PR TITLE
fix(template): address regression in string functions for template engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,9 +439,22 @@ Options to detect notes contained in commit bodies.
 
 ## Templates
 
-The `git-chglog` template uses the `text/template` package and enhanced templating functions provided by [Sprig](http://masterminds.github.io/sprig). For basic usage please refer to the following.
+The `git-chglog` template uses the `text/template` package and enhanced templating functions provided by [Sprig]. For basic usage please refer to the following.
 
-> [text/template](https://golang.org/pkg/text/template/)
+- [text/template](https://golang.org/pkg/text/template/)
+- [Sprig]
+
+We have implemented the following custom template functions. These override functions provided by [Sprig].
+
+| Name         | Signature                                     | Description                                                                   |
+| :----------- | :-------------------------------------------- | :---------------------------------------------------------------------------- |
+| `contains`   | `func(s, substr string) bool`                 | Reports whether `substr` is within `s` using `strings.Contains`               |
+| `datetime`   | `func(layout string, input time.Time) string` | Generate a formatted Date string based on layout                              |
+| `hasPrefix`  | `func(s, prefix string) bool`                 | Tests whether the string `s` begins with `prefix` using `strings.HasPrefix`   |
+| `hasSuffix`  | `func(s, suffix string) bool`                 | Tests whether the string `s` ends with `suffix`. using `strings.HasPrefix`    |
+| `indent`     | `func(s string, n int) string`                | Indent all lines of `s` by `n` spaces                                         |
+| `replace`    | `func(s, old, new string, n int) string`      | Replace `old` with `new` within string `s`, `n` times using `strings.Replace` |
+| `upperFirst` | `func(s string) string`                       | Upper case the first character of a string                                    |
 
 If you are not satisfied with the prepared template please try customizing one.
 
@@ -729,3 +742,4 @@ See [CHANGELOG.md](./CHANGELOG.md)
 [golangci-lint]: https://golangci-lint.run/usage/install/#local-installation
 [issues]: https://github.com/git-chglog/git-chglog/issues
 [git-chglog/artwork]: https://github.com/git-chglog/artwork
+[Sprig]: http://masterminds.github.io/sprig

--- a/chglog.go
+++ b/chglog.go
@@ -340,6 +340,13 @@ func (gen *Generator) render(w io.Writer, unreleased *Unreleased, versions []*Ve
 			pad := strings.Repeat(" ", n)
 			return pad + strings.ReplaceAll(s, "\n", "\n"+pad)
 		},
+		// While Sprig provides these functions, they change the standard input
+		// order which leads to a regression. For an example see:
+		// https://github.com/Masterminds/sprig/blob/master/functions.go#L149
+		"contains":  strings.Contains,
+		"hasPrefix": strings.HasPrefix,
+		"hasSuffix": strings.HasSuffix,
+		"replace":   strings.Replace,
 	}
 
 	fname := filepath.Base(gen.config.Template)


### PR DESCRIPTION
## What does this do / why do we need it?

User reported regression in template function behavior.

See #139 

## How this PR fixes the problem?

It appears that `Sprig` flips the inputs of the `contains`, `hasPrefix`, `replace`
and `hasSuffix` `strings` methods. This appears to be the cause of the regression.

See: https://github.com/Masterminds/sprig/blob/master/functions.go#L149-L152

This results in a regression against the previous implementations of the template
functions.

## What should your reviewer look out for in this PR?

List of Sprig template functions and comments to implementations: https://github.com/Masterminds/sprig/blob/master/functions.go#L149

## Check lists

* [x] Test passed
* [x] Coding style (indentation, etc)


## Additional Comments (if any)

I went back to the previous (pre-Sprig) implementation of our template functions to ensure that we cover any other functions that may have a change in interface. This is when I noted that `replace` has a change in behavior.

I have updated the `README` with a table of custom template functions as well.

## Which issue(s) does this PR fix?

fixes #139
