### PR TITLE
fix: add CommitGroupTitleOrder back to Options

### DIFF
--- a/cmd/git-chglog/config.go
+++ b/cmd/git-chglog/config.go
@@ -316,6 +316,7 @@ func (config *Config) Convert(ctx *CLIContext) *chglog.Config {
 			CommitGroupBy:               opts.CommitGroups.GroupBy,
 			CommitGroupSortBy:           opts.CommitGroups.SortBy,
 			CommitGroupTitleMaps:        opts.CommitGroups.TitleMaps,
+			CommitGroupTitleOrder:       opts.CommitGroups.TitleOrder,
 			HeaderPattern:               opts.Header.Pattern,
 			HeaderPatternMaps:           opts.Header.PatternMaps,
 			IssuePrefix:                 opts.Issues.Prefix,


### PR DESCRIPTION
<!-- Thank you for your contribution to git-chglog! Please replace {Please write here} with your description -->


## What does this do / why do we need it?

This was, accidentally, removed in part of one PR a while back and
caused the Custom sort to not work properly.


## Check lists

* [x] Test passed
* [x] Coding style (indentation, etc)

## Which issue(s) does this PR fix?

fixes #140
