### PR TITLE
feat: Automatic link for gitlab merge requests

### DIFF
--- a/processor.go
+++ b/processor.go
@@ -70,12 +70,14 @@ func (p *GitHubProcessor) addLinks(input string) string {
 //
 // The following processing is performed
 //  - Mentions automatic link (@tsuyoshiwada -> [@tsuyoshiwada](https://gitlab.com/tsuyoshiwada))
-//  - Automatic link to references (#123 -> [#123](https://gitlab.com/owner/repo/issues/123))
+//  - Automatic link to references issues (#123 -> [#123](https://gitlab.com/owner/repo/issues/123))
+//  - Automatic link to references merge request (!123 -> [#123](https://gitlab.com/owner/repo/merge_requests/123))
 type GitLabProcessor struct {
-	Host      string // Host name used for link destination. Note: You must include the protocol (e.g. "https://gitlab.com")
-	config    *Config
-	reMention *regexp.Regexp
-	reIssue   *regexp.Regexp
+	Host           string // Host name used for link destination. Note: You must include the protocol (e.g. "https://gitlab.com")
+	config         *Config
+	reMention      *regexp.Regexp
+	reIssue        *regexp.Regexp
+	reMergeRequest *regexp.Regexp
 }
 
 // Bootstrap ...
@@ -90,6 +92,7 @@ func (p *GitLabProcessor) Bootstrap(config *Config) {
 
 	p.reMention = regexp.MustCompile(`@(\w+)`)
 	p.reIssue = regexp.MustCompile(`(?i)#(\d+)`)
+	p.reMergeRequest = regexp.MustCompile(`(?i)!(\d+)`)
 }
 
 // ProcessCommit ...
@@ -117,6 +120,9 @@ func (p *GitLabProcessor) addLinks(input string) string {
 
 	// issues
 	input = p.reIssue.ReplaceAllString(input, "[#$1]("+repoURL+"/issues/$1)")
+
+	// merge requests
+	input = p.reMergeRequest.ReplaceAllString(input, "[!$1]("+repoURL+"/merge_requests/$1)")
 
 	return input
 }

--- a/processor_test.go
+++ b/processor_test.go
@@ -83,30 +83,34 @@ func TestGitLabProcessor(t *testing.T) {
 
 	assert.Equal(
 		&Commit{
-			Header:  "message [@foo](https://gitlab.com/foo) [#123](https://example.com/issues/123)",
-			Subject: "message [@foo](https://gitlab.com/foo) [#123](https://example.com/issues/123)",
+			Header:  "message [@foo](https://gitlab.com/foo) [#123](https://example.com/issues/123) [!345](https://example.com/merge_requests/345)",
+			Subject: "message [@foo](https://gitlab.com/foo) [#123](https://example.com/issues/123) [!345](https://example.com/merge_requests/345)",
 			Body: `issue [#456](https://example.com/issues/456)
 multiline [#789](https://example.com/issues/789)
+merge request [!345](https://example.com/merge_requests/345)
 [@foo](https://gitlab.com/foo), [@bar](https://gitlab.com/bar)`,
 			Notes: []*Note{
 				{
-					Body: `issue1 [#11](https://example.com/issues/11)
+					Body: `issue1 [#11](https://example.com/issues/11) [!33](https://example.com/merge_requests/33)
 issue2 [#22](https://example.com/issues/22)
+merge request [!33](https://example.com/merge_requests/33)
 gh-56 hoge fuga`,
 				},
 			},
 		},
 		processor.ProcessCommit(
 			&Commit{
-				Header:  "message @foo #123",
-				Subject: "message @foo #123",
+				Header:  "message @foo #123 !345",
+				Subject: "message @foo #123 !345",
 				Body: `issue #456
 multiline #789
+merge request !345
 @foo, @bar`,
 				Notes: []*Note{
 					{
-						Body: `issue1 #11
+						Body: `issue1 #11 !33
 issue2 #22
+merge request !33
 gh-56 hoge fuga`,
 					},
 				},
@@ -117,13 +121,13 @@ gh-56 hoge fuga`,
 	assert.Equal(
 		&Commit{
 			Revert: &Revert{
-				Header: "revert header [@mention](https://gitlab.com/mention) [#123](https://example.com/issues/123)",
+				Header: "revert header [@mention](https://gitlab.com/mention) [#123](https://example.com/issues/123) [!345](https://example.com/merge_requests/345)",
 			},
 		},
 		processor.ProcessCommit(
 			&Commit{
 				Revert: &Revert{
-					Header: "revert header @mention #123",
+					Header: "revert header @mention #123 !345",
 				},
 			},
 		),


### PR DESCRIPTION
## What does this do / why do we need it?

This will add link for merge requests for gitlab style. See  https://github.com/git-chglog/git-chglog/issues/159 for more details.

## How this PR fixes the problem?

It follow gitlab merge request links standards.


## Check lists

* [x] Test passed
* [x] Coding style (indentation, etc)

## Which issue(s) does this PR fix?

fixes https://github.com/git-chglog/git-chglog/issues/159

