### PR TITLE
ci(workflows): 🔧  Remove Manual if-contains-skip-check Github Workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-20.04
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -45,7 +44,6 @@ jobs:
 
   lint:
     runs-on: ubuntu-20.04
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,6 @@ env:
 jobs:
   docker:
     runs-on: ubuntu-20.04
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,6 @@ env:
 jobs:
   goreleaser:
     runs-on: ubuntu-20.04
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
## What does this do / why do we need it?

As of February 8th 2021, Github Actions (or GHA) now supports skipping commits! The following patterns are identified when attempting to skips a commit:

> [skip ci], [ci skip], [no ci], [skip actions], or [actions skip]

More information can be found in Github's February 8th [blog post](https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/)


## How this PR fixes the problem?

This removes the unnecessary if-check manual step now that this feature is covered by Github Actions. 


## What should your reviewer look out for in this PR?

Make sure the pipelines operate as they do today! Ensure they skip any commits with the pattern listed above!


## Check lists

* [ ] Test passed
* [x] Coding style (indentation, etc)


## Additional Comments (if any)

N/A


## Which issue(s) does this PR fix?

N/A 
