### PR TITLE
feat: ability to set changelog title using cli argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ go get -u github.com/git-chglog/git-chglog/cmd/git-chglog
 ```
 
 ### [Docker](https://www.docker.com/)
-The compiled docker images are maintained on [quay.io](https://quay.io/repository/git-chglog/git-chglog). 
+The compiled docker images are maintained on [quay.io](https://quay.io/repository/git-chglog/git-chglog).
 We maintain the following tags:
 - `edge`: Image that is build from the current `HEAD` of the main line branch.
 - `latest`: Image that is built from the [latest released version](https://github.com/git-chglog/git-chglog/releases)
@@ -196,6 +196,7 @@ OPTIONS:
   --path value                Filter commits by path(s). Can use multiple times.
   --config value, -c value    specifies a different configuration file to pick up (default: ".chglog/config.yml")
   --template value, -t value  specifies a template file to pick up. If not specified, use the one in config
+  --title value               specifies changelog title. If not specified, use 'title' in config
   --repository-url value      specifies git repo URL. If not specified, use 'repository_url' in config
   --output value, -o value    output path and filename for the changelogs. If not specified, output to stdout
   --next-tag value            treat unreleased commits as specified tags (EXPERIMENTAL)

--- a/cmd/git-chglog/config.go
+++ b/cmd/git-chglog/config.go
@@ -302,7 +302,7 @@ func (config *Config) Convert(ctx *CLIContext) *chglog.Config {
 		WorkingDir: ctx.WorkingDir,
 		Template:   orValue(ctx.Template, config.Template),
 		Info: &chglog.Info{
-			Title:         info.Title,
+			Title:         orValue(ctx.Title, info.Title),
 			RepositoryURL: orValue(ctx.RepositoryURL, info.RepositoryURL),
 		},
 		Options: &chglog.Options{

--- a/cmd/git-chglog/config_test.go
+++ b/cmd/git-chglog/config_test.go
@@ -45,26 +45,32 @@ func TestConfigNormalize(t *testing.T) {
 func TestConfigConvert(t *testing.T) {
 	var patternInFile = "pattern in config"
 	var patternInArgs = "pattern in cli"
+	var titleInFile = "title in file"
+	var titleInArgs = "title in args"
 	assert := assert.New(t)
 	// basic
 	config := &Config{
 		Info: Info{
 			RepositoryURL: "https://example.com/foo/bar/",
+			Title:         titleInFile,
 		},
 		Options: Options{TagFilterPattern: patternInFile},
 	}
-	cli := &CLIContext{TagFilterPattern: patternInArgs}
+	cli := &CLIContext{TagFilterPattern: patternInArgs, Title: titleInArgs}
 	cfg := config.Convert(cli)
 	assert.Equal(cfg.Options.TagFilterPattern, patternInArgs)
+	assert.Equal(cfg.Info.Title, titleInArgs)
 
 	config = &Config{
 		Info: Info{
 			RepositoryURL: "https://example.com/foo/bar/",
+			Title:         titleInFile,
 		},
 		Options: Options{TagFilterPattern: patternInFile},
 	}
 	cli = &CLIContext{}
 	cfg = config.Convert(cli)
 	assert.Equal(cfg.Options.TagFilterPattern, patternInFile)
+	assert.Equal(cfg.Info.Title, titleInFile)
 
 }

--- a/cmd/git-chglog/context.go
+++ b/cmd/git-chglog/context.go
@@ -11,6 +11,7 @@ type CLIContext struct {
 	Stderr           io.Writer
 	ConfigPath       string
 	Template         string
+	Title            string
 	RepositoryURL    string
 	OutputPath       string
 	Silent           bool

--- a/cmd/git-chglog/main.go
+++ b/cmd/git-chglog/main.go
@@ -107,6 +107,12 @@ func CreateApp(actionFunc cli.ActionFunc) *cli.App {
 			Usage:   "specifies a template file to pick up. If not specified, use the one in config",
 		},
 
+		// changelog title
+		&cli.StringFlag{
+			Name:  "title",
+			Usage: "specifies changelog title. If not specified, use 'title' in config",
+		},
+
 		// repository url
 		&cli.StringFlag{
 			Name:  "repository-url",
@@ -234,6 +240,7 @@ func AppAction(c *cli.Context) error {
 			Stderr:           colorable.NewColorableStderr(),
 			ConfigPath:       c.String("config"),
 			Template:         c.String("template"),
+			Title:            c.String("title"),
 			RepositoryURL:    c.String("repository-url"),
 			OutputPath:       c.String("output"),
 			Silent:           c.Bool("silent"),


### PR DESCRIPTION
<!-- Thank you for your contribution to git-chglog! Please replace {Please write here} with your description -->


## What does this do / why do we need it?

We would like to have a single `git-chglog` configuration and template for multiple projects and have
individual changelog title per project

## How this PR fixes the problem?

The PR adds the `--title` cli argument that overrides the default `info.title` value if present

## What should your reviewer look out for in this PR?

This works similarly to the `--repository-url` argument, the same approach and copied behaviour.

## Check lists

* [ ] Test passed
* [ ] Coding style (indentation, etc)