### PR TITLE
feat: add other commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,13 @@ The basic templates are as follows.
 {{ end }}
 {{ end -}}
 {{ end -}}
+
+{{- if .Unreleased.OtherCommits -}}
+### Others
+{{ range .Unreleased.OtherCommits -}}
+- {{ .Header }}
+{{ end -}}
+{{ end -}}
 {{ end -}}
 
 {{ range .Versions }}
@@ -509,6 +516,13 @@ The basic templates are as follows.
 {{ range .Notes }}
 {{ .Body }}
 {{ end }}
+{{ end -}}
+{{ end -}}
+
+{{- if .OtherCommits -}}
+### Others
+{{ range .OtherCommits -}}
+- {{ .Header }}
 {{ end -}}
 {{ end -}}
 {{ end -}}

--- a/chglog.go
+++ b/chglog.go
@@ -202,7 +202,7 @@ func (gen *Generator) readVersions(tags []*Tag, first string) ([]*Version, error
 			return nil, err
 		}
 
-		commitGroups, mergeCommits, revertCommits, noteGroups := gen.commitExtractor.Extract(commits)
+		commitGroups, mergeCommits, revertCommits, otherCommits, noteGroups := gen.commitExtractor.Extract(commits)
 
 		versions = append(versions, &Version{
 			Tag:           tag,
@@ -210,6 +210,7 @@ func (gen *Generator) readVersions(tags []*Tag, first string) ([]*Version, error
 			Commits:       commits,
 			MergeCommits:  mergeCommits,
 			RevertCommits: revertCommits,
+			OtherCommits:  otherCommits,
 			NoteGroups:    noteGroups,
 		})
 
@@ -238,13 +239,14 @@ func (gen *Generator) readUnreleased(tags []*Tag) (*Unreleased, error) {
 		return nil, err
 	}
 
-	commitGroups, mergeCommits, revertCommits, noteGroups := gen.commitExtractor.Extract(commits)
+	commitGroups, mergeCommits, revertCommits, otherCommits, noteGroups := gen.commitExtractor.Extract(commits)
 
 	unreleased := &Unreleased{
 		CommitGroups:  commitGroups,
 		Commits:       commits,
 		MergeCommits:  mergeCommits,
 		RevertCommits: revertCommits,
+		OtherCommits:  otherCommits,
 		NoteGroups:    noteGroups,
 	}
 

--- a/commit_extractor.go
+++ b/commit_extractor.go
@@ -15,11 +15,12 @@ func newCommitExtractor(opts *Options) *commitExtractor {
 	}
 }
 
-func (e *commitExtractor) Extract(commits []*Commit) ([]*CommitGroup, []*Commit, []*Commit, []*NoteGroup) {
+func (e *commitExtractor) Extract(commits []*Commit) ([]*CommitGroup, []*Commit, []*Commit, []*Commit, []*NoteGroup) {
 	commitGroups := []*CommitGroup{}
 	noteGroups := []*NoteGroup{}
 	mergeCommits := []*Commit{}
 	revertCommits := []*Commit{}
+	otherCommits := []*Commit{}
 
 	filteredCommits := commitFilter(commits, e.opts.CommitFilters, e.opts.NoCaseSensitive)
 
@@ -32,6 +33,10 @@ func (e *commitExtractor) Extract(commits []*Commit) ([]*CommitGroup, []*Commit,
 		if commit.Revert != nil {
 			revertCommits = append(revertCommits, commit)
 			continue
+		}
+
+		if commit.Type == "" {
+			otherCommits = append(otherCommits, commit)
 		}
 	}
 
@@ -46,7 +51,7 @@ func (e *commitExtractor) Extract(commits []*Commit) ([]*CommitGroup, []*Commit,
 	e.sortCommitGroups(commitGroups)
 	e.sortNoteGroups(noteGroups)
 
-	return commitGroups, mergeCommits, revertCommits, noteGroups
+	return commitGroups, mergeCommits, revertCommits, otherCommits, noteGroups
 }
 
 func (e *commitExtractor) processCommitGroups(groups *[]*CommitGroup, commit *Commit, noCaseSensitive bool) {

--- a/commit_extractor_test.go
+++ b/commit_extractor_test.go
@@ -76,9 +76,16 @@ func TestCommitExtractor(t *testing.T) {
 				Header: "REVERT1",
 			},
 		},
+		// [6]
+		{
+			Type:   "",
+			Scope:  "",
+			Header: "Other",
+			Notes:  []*Note{},
+		},
 	}
 
-	commitGroups, mergeCommits, revertCommits, noteGroups := extractor.Extract(fixtures)
+	commitGroups, mergeCommits, revertCommits, otherCommits, noteGroups := extractor.Extract(fixtures)
 
 	assert.Equal([]*CommitGroup{
 		{
@@ -106,6 +113,10 @@ func TestCommitExtractor(t *testing.T) {
 	assert.Equal([]*Commit{
 		fixtures[5],
 	}, revertCommits)
+
+	assert.Equal([]*Commit{
+		fixtures[6],
+	}, otherCommits)
 
 	assert.Equal([]*NoteGroup{
 		{
@@ -207,9 +218,16 @@ func TestCommitOrderExtractor(t *testing.T) {
 				Header: "REVERT1",
 			},
 		},
+		// [6]
+		{
+			Type:   "",
+			Scope:  "",
+			Header: "Other",
+			Notes:  []*Note{},
+		},
 	}
 
-	commitGroups, mergeCommits, revertCommits, noteGroups := extractor.Extract(fixtures)
+	commitGroups, mergeCommits, revertCommits, otherCommits, noteGroups := extractor.Extract(fixtures)
 
 	assert.Equal([]*CommitGroup{
 		{
@@ -237,6 +255,10 @@ func TestCommitOrderExtractor(t *testing.T) {
 	assert.Equal([]*Commit{
 		fixtures[5],
 	}, revertCommits)
+
+	assert.Equal([]*Commit{
+		fixtures[6],
+	}, otherCommits)
 
 	assert.Equal([]*NoteGroup{
 		{

--- a/fields.go
+++ b/fields.go
@@ -120,6 +120,7 @@ type Version struct {
 	Commits       []*Commit
 	MergeCommits  []*Commit
 	RevertCommits []*Commit
+	OtherCommits  []*Commit
 	NoteGroups    []*NoteGroup
 }
 
@@ -129,5 +130,6 @@ type Unreleased struct {
 	Commits       []*Commit
 	MergeCommits  []*Commit
 	RevertCommits []*Commit
+	OtherCommits  []*Commit
 	NoteGroups    []*NoteGroup
 }


### PR DESCRIPTION
## What does this do / why do we need it?

When we encounter commit messages that don't match the rules, we can't see them


## How this PR fixes the problem?

We can see the commit messages that don't match the rules


## What should your reviewer look out for in this PR?

OtherCommits may contain the words merge or revert, which may be the result of a mismatched merge or revert rule


## Check lists

* [ ] Test passed
* [ ] Coding style (indentation, etc)
