### PR TITLE
feat: track changed files for commit

### DIFF
--- a/commit_parser.go
+++ b/commit_parser.go
@@ -169,7 +169,9 @@ func (p *commitParser) parseCommit(input string) (*Commit, error) {
 	if err != nil {
 		return nil, err
 	}
-	commit.ChangedFiles = strings.Split(out, "/n")
+	if len(out) > 0 {
+		commit.ChangedFiles = strings.Split(out, "\n")
+	}
 
 	return commit, nil
 }

--- a/commit_parser_test.go
+++ b/commit_parser_test.go
@@ -19,11 +19,17 @@ func TestCommitParserParse(t *testing.T) {
 
 	mock := &mockClient{
 		ReturnExec: func(subcmd string, args ...string) (string, error) {
-			if subcmd != "log" {
+			var filename string
+			switch subcmd {
+			case "log":
+				filename = "gitlog.txt"
+			case "diff-tree":
+				filename = "gitchanges.txt"
+			default:
 				return "", errors.New("")
 			}
 
-			bytes, _ := ioutil.ReadFile(filepath.Join("testdata", "gitlog.txt"))
+			bytes, _ := ioutil.ReadFile(filepath.Join("testdata", filename))
 
 			return string(bytes), nil
 		},
@@ -103,14 +109,15 @@ func TestCommitParserParse(t *testing.T) {
 					Source: "",
 				},
 			},
-			Notes:       []*Note{},
-			Mentions:    []string{},
-			Header:      "feat(*): Add new feature #123",
-			Type:        "feat",
-			Scope:       "*",
-			Subject:     "Add new feature #123",
-			Body:        "",
-			TrimmedBody: "",
+			Notes:        []*Note{},
+			Mentions:     []string{},
+			Header:       "feat(*): Add new feature #123",
+			Type:         "feat",
+			Scope:        "*",
+			Subject:      "Add new feature #123",
+			Body:         "",
+			TrimmedBody:  "",
+			ChangedFiles: []string{"Dockerfile", "go.mod", "go.sum"},
 		},
 		{
 			Hash: &Hash{
@@ -167,7 +174,8 @@ Fixes #3
 Closes #1
 
 BREAKING CHANGE: This is breaking point message.`,
-			TrimmedBody: `This is body message.`,
+			TrimmedBody:  `This is body message.`,
+			ChangedFiles: []string{"Dockerfile", "go.mod", "go.sum"},
 		},
 		{
 			Hash: &Hash{
@@ -202,7 +210,8 @@ BREAKING CHANGE: This is breaking point message.`,
 @tsuyoshiwada
 @hogefuga
 @FooBarBaz`,
-			TrimmedBody: `Has mention body`,
+			TrimmedBody:  `Has mention body`,
+			ChangedFiles: []string{"Dockerfile", "go.mod", "go.sum"},
 		},
 		{
 			Hash: &Hash{
@@ -283,7 +292,8 @@ class MyController extends Controller {
 
 Fixes #123
 Closes username/repository#456`, "```", "```"),
-			TrimmedBody: `This mixed body message.`,
+			TrimmedBody:  `This mixed body message.`,
+			ChangedFiles: []string{"Dockerfile", "go.mod", "go.sum"},
 		},
 		{
 			Hash: &Hash{
@@ -304,15 +314,16 @@ Closes username/repository#456`, "```", "```"),
 			Revert: &Revert{
 				Header: "fix(core): commit message",
 			},
-			Refs:        []*Ref{},
-			Notes:       []*Note{},
-			Mentions:    []string{},
-			Header:      "Revert \"fix(core): commit message\"",
-			Type:        "",
-			Scope:       "",
-			Subject:     "",
-			Body:        "This reverts commit f755db78dcdf461dc42e709b3ab728ceba353d1d.",
-			TrimmedBody: "This reverts commit f755db78dcdf461dc42e709b3ab728ceba353d1d.",
+			Refs:         []*Ref{},
+			Notes:        []*Note{},
+			Mentions:     []string{},
+			Header:       "Revert \"fix(core): commit message\"",
+			Type:         "",
+			Scope:        "",
+			Subject:      "",
+			Body:         "This reverts commit f755db78dcdf461dc42e709b3ab728ceba353d1d.",
+			TrimmedBody:  "This reverts commit f755db78dcdf461dc42e709b3ab728ceba353d1d.",
+			ChangedFiles: []string{"Dockerfile", "go.mod", "go.sum"},
 		},
 	}, commits)
 }
@@ -372,11 +383,17 @@ func TestCommitParserParseWithJira(t *testing.T) {
 
 	mock := &mockClient{
 		ReturnExec: func(subcmd string, args ...string) (string, error) {
-			if subcmd != "log" {
+			var filename string
+			switch subcmd {
+			case "log":
+				filename = "gitlog_jira.txt"
+			case "diff-tree":
+				filename = "gitchanges.txt"
+			default:
 				return "", errors.New("")
 			}
 
-			bytes, _ := ioutil.ReadFile(filepath.Join("testdata", "gitlog_jira.txt"))
+			bytes, _ := ioutil.ReadFile(filepath.Join("testdata", filename))
 
 			return string(bytes), nil
 		},

--- a/fields.go
+++ b/fields.go
@@ -68,24 +68,25 @@ type JiraIssue struct {
 
 // Commit data
 type Commit struct {
-	Hash        *Hash
-	Author      *Author
-	Committer   *Committer
-	Merge       *Merge  // If it is not a merge commit, `nil` is assigned
-	Revert      *Revert // If it is not a revert commit, `nil` is assigned
-	Refs        []*Ref
-	Notes       []*Note
-	Mentions    []string   // Name of the user included in the commit header or body
-	CoAuthors   []Contact  // (e.g. `Co-authored-by: user <user@email>`)
-	Signers     []Contact  // (e.g. `Signed-off-by: user <user@email>`)
-	JiraIssue   *JiraIssue // If no issue id found in header, `nil` is assigned
-	Header      string     // (e.g. `feat(core)[RNWY-310]: Add new feature`)
-	Type        string     // (e.g. `feat`)
-	Scope       string     // (e.g. `core`)
-	Subject     string     // (e.g. `Add new feature`)
-	JiraIssueID string     // (e.g. `RNWY-310`)
-	Body        string
-	TrimmedBody string // Body without any Notes/Refs/Mentions/CoAuthors/Signers
+	Hash         *Hash
+	Author       *Author
+	Committer    *Committer
+	Merge        *Merge  // If it is not a merge commit, `nil` is assigned
+	Revert       *Revert // If it is not a revert commit, `nil` is assigned
+	Refs         []*Ref
+	Notes        []*Note
+	Mentions     []string   // Name of the user included in the commit header or body
+	CoAuthors    []Contact  // (e.g. `Co-authored-by: user <user@email>`)
+	Signers      []Contact  // (e.g. `Signed-off-by: user <user@email>`)
+	JiraIssue    *JiraIssue // If no issue id found in header, `nil` is assigned
+	Header       string     // (e.g. `feat(core)[RNWY-310]: Add new feature`)
+	Type         string     // (e.g. `feat`)
+	Scope        string     // (e.g. `core`)
+	Subject      string     // (e.g. `Add new feature`)
+	JiraIssueID  string     // (e.g. `RNWY-310`)
+	Body         string
+	TrimmedBody  string // Body without any Notes/Refs/Mentions/CoAuthors/Signers
+	ChangedFiles []string
 }
 
 // CommitGroup is a collection of commits grouped according to the `CommitGroupBy` option

--- a/testdata/gitchanges.txt
+++ b/testdata/gitchanges.txt
@@ -1,0 +1,3 @@
+Dockerfile
+go.mod
+go.sum


### PR DESCRIPTION
<!-- Thank you for your contribution to git-chglog! Please replace {Please write here} with your description -->


## What does this do / why do we need it?

- What this change does is updates the `Commit` struct to track the changed files in the commit.
- Why I would like this change is because I want to use the list of changed files to determine scope within the template. I am looking into using `git-chglog` for the [Telegraf](https://github.com/influxdata/telegraf) project (relevant PR https://github.com/influxdata/telegraf/pull/10730) and it isn't always guaranteed the scope is added correctly before a pull request is merged. Having the list of changed files can help update the template to get a best guess of the scope. Hopefully other users will also find this useful for potential other use cases? 

<details>
<summary>Example template and output</summary>

template:

```html
{{- $scope := .Scope -}}
{{- if not $scope -}}
    {{- range $changed := $commit.ChangedFiles -}}
        {{- if not $scope -}}
            {{- $paths := splitn "/" -1 (regexFind "plugins/(.*){2}/" $changed) -}}
            {{- $scope = join "." (list $paths._1 $paths._2) -}}
        {{- end -}}
    {{- end -}}
{{- end -}}

- {{ if $scope }}**{{ $scope }}:** {{ end }}{{ println (upperFirst (trim $commit.Subject)) }}
```

output:

```markdown
- **inputs.opcua:** Accept non-standard OPC UA OK status by implementing a configurable workaround ([#10384](https://github.com/influxdata/telegraf/issues/10384))
- **outputs.timestream:** Fix batching logic with write records, introduce concurrent requests ([#8947](https://github.com/influxdata/telegraf/issues/8947))
```

The two output examples are missing the scope in the PR, and we would like it to have been the name of the plugin changed, the idea was for it to be a best guess to save time having to figure it out manually.

</details>

## How this PR fixes the problem?

When the commit is being parsed in `parseCommit`, I added a call to `git diff-tree --no-commit-id --name-only -r commit.Hash.Short` to get the list of changed files and add it to the `Commit` struct.

## Check lists

* [x] Test passed
* [x] Coding style (indentation, etc)

Thank you for taking a look.
