### PR TITLE
docs: update Go install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ asdf install git-chglog latest
 #### Go users
 
 ```bash
-go get -u github.com/git-chglog/git-chglog/cmd/git-chglog
+go install github.com/git-chglog/git-chglog/cmd/git-chglog@latest
 ```
 
 ### [Docker](https://www.docker.com/)


### PR DESCRIPTION
## What does this do / why do we need it?

Simply updates the Go install instructions to be compatible with go 1.17 and upwards.