### PR TITLE
feat: support grouping by date

### DIFF
--- a/commit_extractor.go
+++ b/commit_extractor.go
@@ -3,6 +3,7 @@ package chglog
 import (
 	"sort"
 	"strings"
+	"time"
 )
 
 type commitExtractor struct {
@@ -114,14 +115,26 @@ func (e *commitExtractor) commitGroupTitle(commit *Commit) (string, string) {
 	)
 
 	if title, ok := dotGet(commit, e.opts.CommitGroupBy); ok {
-		if v, ok := title.(string); ok {
-			raw = v
-			if t, ok := e.opts.CommitGroupTitleMaps[v]; ok {
-				ttl = t
-			} else {
-				//nolint:staticcheck
-				ttl = strings.Title(raw)
-			}
+		switch titleType := title.(type) {
+		case string:
+			raw = titleType
+		case time.Time:
+			raw = titleType.Format("2006-01-02")
+		case *time.Time:
+			raw = titleType.Format("2006-01-02")
+		case interface {
+			String() string
+		}:
+			raw = titleType.String()
+		default:
+			return "", ""
+		}
+
+		if t, ok := e.opts.CommitGroupTitleMaps[raw]; ok {
+			ttl = t
+		} else {
+			//nolint:staticcheck
+			ttl = strings.Title(raw)
 		}
 	}
 


### PR DESCRIPTION
## What does this do / why do we need it?

Grouping by `.Author.Date` is currently not possible because `time.Time` is not `string`

## How this PR fixes the problem?

Adding a type switch allowing users to use `Author.Date` in the commit group `commit_groups.group_by`

## What should your reviewer look out for in this PR?

Using time.Time currently defaults to the date. Itt might be desirable (in the future) to make this configurable, but in the interest of simplicity I chose to use the internationally acceptable date format `YYYY-MM-DD`.

## Check lists

* [x] Test passed
* [x] Coding style (indentation, etc)
