### PR TITLE
feat: support passing arbitrary key=value pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,24 +195,25 @@ USAGE:
     4. <name>       - Commit contained in <name>.
 
 OPTIONS:
-  --init                      generate the git-chglog configuration file in interactive (default: false)
-  --path value                Filter commits by path(s). Can use multiple times.
-  --config value, -c value    specifies a different configuration file to pick up (default: ".chglog/config.yml")
-  --template value, -t value  specifies a template file to pick up. If not specified, use the one in config
-  --repository-url value      specifies git repo URL. If not specified, use 'repository_url' in config
-  --output value, -o value    output path and filename for the changelogs. If not specified, output to stdout
-  --next-tag value            treat unreleased commits as specified tags (EXPERIMENTAL)
-  --silent                    disable stdout output (default: false)
-  --no-color                  disable color output (default: false) [$NO_COLOR]
-  --no-emoji                  disable emoji output (default: false) [$NO_EMOJI]
-  --no-case                   disable case sensitive filters (default: false)
-  --tag-filter-pattern value  Regular expression of tag filter. Is specified, only matched tags will be picked
-  --jira-url value            Jira URL [$JIRA_URL]
-  --jira-username value       Jira username [$JIRA_USERNAME]
-  --jira-token value          Jira token [$JIRA_TOKEN]
-  --sort value                Specify how to sort tags; currently supports "date" or by "semver" (default: date)
-  --help, -h                  show help (default: false)
-  --version, -v               print the version (default: false)
+  --init                         generate the git-chglog configuration file in interactive (default: false)
+  --arg value [ --arg value ]    Pass arbitrary key=value arguments into your templates. Can use multiple times.
+  --path value                   Filter commits by path(s). Can use multiple times.
+  --config value, -c value       specifies a different configuration file to pick up (default: ".chglog/config.yml")
+  --template value, -t value     specifies a template file to pick up. If not specified, use the one in config
+  --repository-url value         specifies git repo URL. If not specified, use 'repository_url' in config
+  --output value, -o value       output path and filename for the changelogs. If not specified, output to stdout
+  --next-tag value               treat unreleased commits as specified tags (EXPERIMENTAL)
+  --silent                       disable stdout output (default: false)
+  --no-color                     disable color output (default: false) [$NO_COLOR]
+  --no-emoji                     disable emoji output (default: false) [$NO_EMOJI]
+  --no-case                      disable case sensitive filters (default: false)
+  --tag-filter-pattern value     Regular expression of tag filter. Is specified, only matched tags will be picked
+  --jira-url value               Jira URL [$JIRA_URL]
+  --jira-username value          Jira username [$JIRA_USERNAME]
+  --jira-token value             Jira token [$JIRA_TOKEN]
+  --sort value                   Specify how to sort tags; currently supports "date" or by "semver" (default: date)
+  --help, -h                     show help (default: false)
+  --version, -v                  print the version (default: false)
 
 EXAMPLE:
 
@@ -244,6 +245,13 @@ EXAMPLE:
   $ git-chglog --path path/to/my/component --output CHANGELOG.component.md
 
     Filter commits by specific paths or files in git and output to a component specific changelog.
+
+  $ git-chglog --arg buildNumber=59 1.0.0
+
+    The above is a command to generate CHANGELOG including commit of only 1.0.0 while passing the `buildNumber`
+    argument into your template to be accessed like this:
+
+        {{ index .Args "buildNumber" }}
 ```
 
 ### `tag query`

--- a/chglog.go
+++ b/chglog.go
@@ -43,7 +43,8 @@ type Options struct {
 	JiraURL                     string
 	JiraTypeMaps                map[string]string
 	JiraIssueDescriptionPattern string
-	Paths                       []string // Path filter
+	Paths                       []string               // Path filter
+	Args                        map[string]interface{} // key-value arguments to pass into the template
 }
 
 // Info is metadata related to CHANGELOG
@@ -54,6 +55,7 @@ type Info struct {
 
 // RenderData is the data passed to the template
 type RenderData struct {
+	Args       map[string]interface{}
 	Info       *Info
 	Unreleased *Unreleased
 	Versions   []*Version
@@ -355,6 +357,7 @@ func (gen *Generator) render(w io.Writer, unreleased *Unreleased, versions []*Ve
 	t := template.Must(template.New(fname).Funcs(sprig.TxtFuncMap()).Funcs(fmap).ParseFiles(gen.config.Template))
 
 	return t.Execute(w, &RenderData{
+		Args:       gen.config.Options.Args,
 		Info:       gen.config.Info,
 		Unreleased: unreleased,
 		Versions:   versions,

--- a/cmd/git-chglog/config.go
+++ b/cmd/git-chglog/config.go
@@ -281,6 +281,17 @@ func (config *Config) normalizeStyleOfBitbucket() {
 	config.Options = opts
 }
 
+func parseArgs(ss []string) map[string]interface{} {
+	m := make(map[string]interface{}, 0)
+	for _, s := range ss {
+		parts := strings.Split(s, "=")
+		if len(parts) == 2 {
+			m[parts[0]] = parts[1]
+		}
+	}
+	return m
+}
+
 func orValue(str1 string, str2 string) string {
 	if str1 != "" {
 		return str1
@@ -310,6 +321,7 @@ func (config *Config) Convert(ctx *CLIContext) *chglog.Config {
 			TagFilterPattern:            ctx.TagFilterPattern,
 			Sort:                        orValue(ctx.Sort, opts.Sort),
 			NoCaseSensitive:             ctx.NoCaseSensitive,
+			Args:                        parseArgs(ctx.Args),
 			Paths:                       ctx.Paths,
 			CommitFilters:               opts.Commits.Filters,
 			CommitSortBy:                opts.Commits.SortBy,

--- a/cmd/git-chglog/context.go
+++ b/cmd/git-chglog/context.go
@@ -24,6 +24,7 @@ type CLIContext struct {
 	JiraToken        string
 	JiraURL          string
 	Paths            []string
+	Args             []string
 	Sort             string
 }
 

--- a/cmd/git-chglog/main.go
+++ b/cmd/git-chglog/main.go
@@ -24,7 +24,7 @@ func CreateApp(actionFunc cli.ActionFunc) *cli.App {
 %s
   {{.Name}} [options] <tag query>
 
-    There are the following specification methods for <tag query>.
+    There aarere the following specification methods for <tag query>.
 
     1. <old>..<new> - Commit contained in <old> tags from <new>.
     2. <name>..     - Commit from the <name> to the latest tag.
@@ -84,6 +84,12 @@ func CreateApp(actionFunc cli.ActionFunc) *cli.App {
 		&cli.BoolFlag{
 			Name:  "init",
 			Usage: "generate the git-chglog configuration file in interactive",
+		},
+
+		// arg
+		&cli.StringSliceFlag{
+			Name:  "arg",
+			Usage: "Pass arbitrary key=value arguments into your templates. Can use multiple times.",
 		},
 
 		// path
@@ -247,6 +253,7 @@ func AppAction(c *cli.Context) error {
 			JiraToken:        c.String("jira-token"),
 			JiraURL:          c.String("jira-url"),
 			Paths:            c.StringSlice("path"),
+			Args:             c.StringSlice("arg"),
 			Sort:             c.String("sort"),
 		},
 		fs,

--- a/fields.go
+++ b/fields.go
@@ -121,6 +121,7 @@ type Version struct {
 	MergeCommits  []*Commit
 	RevertCommits []*Commit
 	NoteGroups    []*NoteGroup
+	Args          map[string]interface{}
 }
 
 // Unreleased is unreleased commit dataset
@@ -130,4 +131,5 @@ type Unreleased struct {
 	MergeCommits  []*Commit
 	RevertCommits []*Commit
 	NoteGroups    []*NoteGroup
+	Args          map[string]interface{}
 }


### PR DESCRIPTION
## What does this do / why do we need it?

this commit addresses the first part of #261 by allowing the passing of arbitrary key=value arguments into the command line and exposing them as part of RenderData for use in the templates

## How this PR fixes the problem?

A new `--arg` CLI parameter has been added. This supports multiple `key=value` args like so
```
git-chglog --arg key1=val1 --arg key2=val2 1.0.0
```

Those `--arg` values are collected into a slice, then each item split by `=` into a key and a value, then added into a map and exposed on the `RenderData` struct so that they can be referenced in templates like this:

```
{{ index .Args "key1" }} - {{ index .Args "key2" }}
```
which renders
```
val1 - val2
```

## Check lists

* [x] Test passed
* [x] Coding style (indentation, etc)

## Additional Comments (if any)

None.

## Which issue(s) does this PR fix?

fixes #261
