### PR TITLE
test: separate test cases in util/tag-selector tests

### DIFF
--- a/tag_selector_test.go
+++ b/tag_selector_test.go
@@ -1,6 +1,7 @@
 package chglog
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -88,14 +89,17 @@ func TestTagSelector(t *testing.T) {
 	}
 
 	for query, expected := range table {
-		list, from, err := selector.Select(fixtures, query)
-		actual := make([]string, len(list))
-		for i, tag := range list {
-			actual[i] = tag.Name
-		}
+		caseName := fmt.Sprintf("query(%s)", query)
+		t.Run(caseName, func(t *testing.T) {
+			list, from, err := selector.Select(fixtures, query)
+			actual := make([]string, len(list))
+			for i, tag := range list {
+				actual[i] = tag.Name
+			}
 
-		assert.Nil(err)
-		assert.Equal(expected[0:len(expected)-1], actual)
-		assert.Equal(expected[len(expected)-1], from)
+			assert.Nil(err)
+			assert.Equal(expected[0:len(expected)-1], actual)
+			assert.Equal(expected[len(expected)-1], from)
+		})
 	}
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,6 +1,7 @@
 package chglog
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -103,8 +104,11 @@ func TestCompare(t *testing.T) {
 	}
 
 	for _, sa := range table {
-		actual, err := compare(sa.a, sa.op, sa.b)
-		assert.Nil(err)
-		assert.Equal(sa.expected, actual)
+		caseName := fmt.Sprintf("compare(%v%s%v)", sa.a, sa.op, sa.b)
+		t.Run(caseName, func(t *testing.T) {
+			actual, err := compare(sa.a, sa.op, sa.b)
+			assert.Nil(err)
+			assert.Equal(sa.expected, actual)
+		})
 	}
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to git-chglog! Please replace {Please write here} with your description -->


## What does this do / why do we need it?

This PR separates tests in util_test.go and tag_selector_test.go into sub test cases.
This improves the output of these tests and makes clear what tests succeed/fail.

## How this PR fixes the problem?

Use `testing.T`'s method `Run` when asserting each case.

## What should your reviewer look out for in this PR?

You can see what the test changed into with `go test ./... -run='Compare|TagSelector' -v`

## Check lists

* [ ] Test passed
* [ ] Coding style (indentation, etc)


## Additional Comments (if any)

{Please write here}


## Which issue(s) does this PR fix?

I made no issues
